### PR TITLE
Fix in memory dao code problem

### DIFF
--- a/src/main/java/data_access/FirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FirestoreUserDataAccessObject.java
@@ -1,124 +1,124 @@
-package data_access;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.firestore.*;
-
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
-
-import com.google.api.core.ApiFuture;
-import com.google.firebase.cloud.FirestoreClient;
-import com.google.firebase.cloud.StorageClient;
-
-
-import entity.user.*;
-import use_case.login.club_login.ClubLoginDataAccessInterface;
-import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
-import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
-import use_case.login.student_login.StudentLoginDataAccessInterface;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
-/**
- * Persisting memory implementation of the DAO for storing user data
- * This implementation uses Firebase
- */
-public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
-StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
-    private final Firestore db;
-
-    public FirestoreUserDataAccessObject() throws IOException {
-        // TODO fix this to be environment variable
-        FileInputStream serviceAccount =
-                new FileInputStream("/ServiceAccountKey.json");
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        FirebaseApp.initializeApp(options);
-        this.db = FirestoreClient.getFirestore();
-    }
-
-    @Override
-    public boolean existsByName(String username) {
-        DocumentReference docRef = db.collection("users").document(username);
-        ApiFuture<DocumentSnapshot> future = docRef.get();
-        try {
-            DocumentSnapshot document = future.get();
-            return document.exists();
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    @Override
-    public Student getStudent(String username) {
-        DocumentReference docRef = db.collection("users").document(username);
-        ApiFuture<DocumentSnapshot> future = docRef.get();
-        try {
-            DocumentSnapshot document = future.get();
-            if (document.exists()) {
-                return document.toObject(Student.class);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-        }
-        return null; // Return null if no student is found
-    }
-
-    @Override
-    public boolean existsByEmail(String email) {
-        ApiFuture<QuerySnapshot> future = db.collection("users").whereEqualTo("email", email).get();
-        try {
-            return !future.get().isEmpty();
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    @Override
-    public void saveStudent(Student user) {
-        DocumentReference docRef = db.collection("users").document(user.getUsername());
-        ApiFuture<WriteResult> writeResult = docRef.set(user);
-        try {
-            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-        }
-    }
-
-    @Override
-    public void saveClub(Club user) {
-        DocumentReference docRef = db.collection("users").document(user.getUsername());
-        ApiFuture<WriteResult> writeResult = docRef.set(user);
-        try {
-            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-        }
-    }
-
-    @Override
-    public Club getClub(String email) {
-        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
-        try {
-            QuerySnapshot documents = future.get();
-            if (!documents.isEmpty()) {
-                DocumentSnapshot document = documents.getDocuments().get(0);
-                return document.toObject(Club.class);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-        }
-        return null; // Return null if no club is found
-    }
-}
+//package data_access;
+//
+//import com.google.auth.oauth2.GoogleCredentials;
+//import com.google.cloud.firestore.*;
+//
+//import com.google.firebase.FirebaseApp;
+//import com.google.firebase.FirebaseOptions;
+//
+//import com.google.api.core.ApiFuture;
+//import com.google.firebase.cloud.FirestoreClient;
+//import com.google.firebase.cloud.StorageClient;
+//
+//
+//import entity.user.*;
+//import use_case.login.club_login.ClubLoginDataAccessInterface;
+//import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
+//import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
+//import use_case.login.student_login.StudentLoginDataAccessInterface;
+//
+//import java.io.FileInputStream;
+//import java.io.IOException;
+//import java.util.concurrent.ExecutionException;
+//
+///**
+// * Persisting memory implementation of the DAO for storing user data
+// * This implementation uses Firebase
+// */
+//public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
+//StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
+//    private final Firestore db;
+//
+//    public FirestoreUserDataAccessObject() throws IOException {
+//        // TODO fix this to be environment variable
+//        FileInputStream serviceAccount =
+//                new FileInputStream("/ServiceAccountKey.json");
+//
+//        FirebaseOptions options = new FirebaseOptions.Builder()
+//                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+//                .build();
+//
+//        FirebaseApp.initializeApp(options);
+//        this.db = FirestoreClient.getFirestore();
+//    }
+//
+//    @Override
+//    public boolean existsByName(String username) {
+//        DocumentReference docRef = db.collection("users").document(username);
+//        ApiFuture<DocumentSnapshot> future = docRef.get();
+//        try {
+//            DocumentSnapshot document = future.get();
+//            return document.exists();
+//        } catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            return false;
+//        }
+//    }
+//
+//    @Override
+//    public Student getStudent(String username) {
+//        DocumentReference docRef = db.collection("users").document(username);
+//        ApiFuture<DocumentSnapshot> future = docRef.get();
+//        try {
+//            DocumentSnapshot document = future.get();
+//            if (document.exists()) {
+//                return document.toObject(Student.class);
+//            }
+//        } catch (InterruptedException | ExecutionException e) {
+//            e.printStackTrace();
+//        }
+//        return null; // Return null if no student is found
+//    }
+//
+//    @Override
+//    public boolean existsByEmail(String email) {
+//        ApiFuture<QuerySnapshot> future = db.collection("users").whereEqualTo("email", email).get();
+//        try {
+//            return !future.get().isEmpty();
+//        } catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            return false;
+//        }
+//    }
+//
+//    @Override
+//    public void saveStudent(Student user) {
+//        DocumentReference docRef = db.collection("users").document(user.getUsername());
+//        ApiFuture<WriteResult> writeResult = docRef.set(user);
+//        try {
+//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+//        } catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    @Override
+//    public void saveClub(Club user) {
+//        DocumentReference docRef = db.collection("users").document(user.getUsername());
+//        ApiFuture<WriteResult> writeResult = docRef.set(user);
+//        try {
+//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+//        } catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    @Override
+//    public Club getClub(String email) {
+//        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
+//        try {
+//            QuerySnapshot documents = future.get();
+//            if (!documents.isEmpty()) {
+//                DocumentSnapshot document = documents.getDocuments().get(0);
+//                return document.toObject(Club.class);
+//            }
+//        } catch (InterruptedException | ExecutionException e) {
+//            e.printStackTrace();
+//        }
+//        return null; // Return null if no club is found
+//    }
+//}

--- a/src/main/java/data_access/FirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FirestoreUserDataAccessObject.java
@@ -84,7 +84,7 @@ StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
     }
 
     @Override
-    public void saveStudent(User user) {
+    public void saveStudent(Student user) {
         DocumentReference docRef = db.collection("users").document(user.getUsername());
         ApiFuture<WriteResult> writeResult = docRef.set(user);
         try {
@@ -96,7 +96,7 @@ StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
     }
 
     @Override
-    public void saveClub(User user) {
+    public void saveClub(Club user) {
         DocumentReference docRef = db.collection("users").document(user.getUsername());
         ApiFuture<WriteResult> writeResult = docRef.set(user);
         try {

--- a/src/main/java/data_access/UserDataAccessObject.java
+++ b/src/main/java/data_access/UserDataAccessObject.java
@@ -19,14 +19,24 @@ import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
 public class UserDataAccessObject implements ClubSignupUserDataAccessInterface, StudentSignupUserDataAccessInterface,
         ClubLoginDataAccessInterface, StudentLoginDataAccessInterface, ClubCreatePostUserDataAccessInterface {
 
-    private final ArrayList<User> userArrayList = new ArrayList<>();
+    private final ArrayList<Student> studentArrayList = new ArrayList<>();
+    private final ArrayList<Club> clubArrayList = new ArrayList<>();
 
     @Override
     public boolean existsByName(String identifier) {
         boolean found = false;
-        for (User user : userArrayList) {
-            if (user.getUsername().equals(identifier)) {
+        for (Club club : clubArrayList) {
+            if (club.getUsername().equals(identifier)) {
                 found = true;
+                break;
+            }
+        }
+        if (!found) {
+            for (Student student : studentArrayList) {
+                if (student.getUsername().equals(identifier)) {
+                    found = true;
+                    break;
+                }
             }
         }
         return found;
@@ -35,54 +45,62 @@ public class UserDataAccessObject implements ClubSignupUserDataAccessInterface, 
     @Override
     public boolean existsByEmail(String identifier) {
         boolean found = false;
-        for (User user: userArrayList) {
-            if (user.getEmail().equals(identifier)) {
+        for (Club club : clubArrayList) {
+            if (club.getEmail().equals(identifier)) {
                 found = true;
+                break;
+            }
+        }
+        if (!found) {
+            for (Student student : studentArrayList) {
+                if (student.getEmail().equals(identifier)) {
+                    found = true;
+                    break;
+                }
             }
         }
         return found;
     }
 
     @Override
-    public void saveClub(User club) {
-        userArrayList.add((Club) club);
+    public void saveClub(Club club) {
+        clubArrayList.add(club);
     }
 
     @Override
-    public void saveStudent(User student) {
-        userArrayList.add((Student) student);
+    public void saveStudent(Student student) {
+        studentArrayList.add(student);
     }
 
     @Override
     public Club getClub(String email) {
-        Club foundClub = null;
-        for (User user : userArrayList) {
-            if (user.getEmail().equals(email)) {
-                foundClub = (Club) user;
+        Club clubFound = null;
+        for (Club club : clubArrayList) {
+            if (club.getEmail().equals(email)) {
+                clubFound = club;
             }
         }
-        return foundClub;
+        // This should not be returned as null since the precondition states that the club must exist.
+        return clubFound;
     }
 
     @Override
     public Student getStudent(String email) {
         Student foundStudent = null;
-        for (User user : userArrayList) {
-            if (user.getEmail().equals(email)) {
-                foundStudent = (Student) user;
+        for (Student student : studentArrayList) {
+            if (student.getEmail().equals(email)) {
+                foundStudent = student;
             }
         }
+        // This should not be returned as null since the precondition states that the student must exist.
         return foundStudent;
     }
 
     @Override
     public void savePost(Post post, Club club) {
-        for (User user : userArrayList) {
-            if (user.getEmail().equals(club.getEmail())) {
-                final Club isClub = (Club) user;
-                isClub.addClubPost(post);
-                break;
-
+        for (Club current: clubArrayList) {
+            if (current.getUsername().equals(club.getUsername())) {
+                current.addClubPost(post);
             }
         }
     }

--- a/src/main/java/data_access/UserDataAccessObject.java
+++ b/src/main/java/data_access/UserDataAccessObject.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import entity.post.Post;
 import entity.user.Club;
 import entity.user.Student;
-import entity.user.User;
 import use_case.club_create_post.ClubCreatePostUserDataAccessInterface;
 import use_case.login.club_login.ClubLoginDataAccessInterface;
 import use_case.login.student_login.StudentLoginDataAccessInterface;
@@ -23,7 +22,7 @@ public class UserDataAccessObject implements ClubSignupUserDataAccessInterface, 
     private final ArrayList<Club> clubArrayList = new ArrayList<>();
 
     @Override
-    public boolean existsByName(String identifier) {
+    public boolean existsByNameClub(String identifier) {
         boolean found = false;
         for (Club club : clubArrayList) {
             if (club.getUsername().equals(identifier)) {
@@ -31,19 +30,23 @@ public class UserDataAccessObject implements ClubSignupUserDataAccessInterface, 
                 break;
             }
         }
-        if (!found) {
-            for (Student student : studentArrayList) {
-                if (student.getUsername().equals(identifier)) {
-                    found = true;
-                    break;
-                }
+        return found;
+    }
+
+    @Override
+    public boolean existsByNameStudent(String username) {
+        boolean found = false;
+        for (Student student : studentArrayList) {
+            if (student.getUsername().equals(username)) {
+                found = true;
+                break;
             }
         }
         return found;
     }
 
     @Override
-    public boolean existsByEmail(String identifier) {
+    public boolean existsByEmailClub(String identifier) {
         boolean found = false;
         for (Club club : clubArrayList) {
             if (club.getEmail().equals(identifier)) {
@@ -51,6 +54,12 @@ public class UserDataAccessObject implements ClubSignupUserDataAccessInterface, 
                 break;
             }
         }
+        return found;
+    }
+
+    @Override
+    public boolean existsByEmailStudent(String identifier) {
+        boolean found = false;
         if (!found) {
             for (Student student : studentArrayList) {
                 if (student.getEmail().equals(identifier)) {

--- a/src/main/java/use_case/club_create_post/ClubCreatePostUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostUserDataAccessInterface.java
@@ -16,6 +16,7 @@ public interface ClubCreatePostUserDataAccessInterface {
 
     /**
      * Get the club with the given email.
+     * Precondition: The club must exist.
      * @param email the email of the club
      * @return the club with matching email
      */

--- a/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
+++ b/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
@@ -23,7 +23,7 @@ public class ClubGetMembersInteractor {
      */
     public void execute(ClubGetMembersInputData inputData) {
         final String email = inputData.getEmail();
-        if (!getMembersDataAccessObject.existsByEmail(email)) {
+        if (!getMembersDataAccessObject.existsByEmailClub(email)) {
             getMembersPresenter.prepareFailView(email + ": Account does not exist.");
         }
         else {

--- a/src/main/java/use_case/club_get_members/ClubGetMembersUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_get_members/ClubGetMembersUserDataAccessInterface.java
@@ -16,6 +16,7 @@ public interface ClubGetMembersUserDataAccessInterface {
 
     /**
      * Returns the Clubs with given email.
+     * Precondition: The club must exist.
      * @param email of the club
      * @return the club with matching email
      */

--- a/src/main/java/use_case/club_get_members/ClubGetMembersUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_get_members/ClubGetMembersUserDataAccessInterface.java
@@ -12,7 +12,7 @@ public interface ClubGetMembersUserDataAccessInterface {
      * @param email of the potential club
      * @return true if the club exists with given email
      */
-    boolean existsByEmail(String email);
+    boolean existsByEmailClub(String email);
 
     /**
      * Returns the Clubs with given email.

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
@@ -25,7 +25,7 @@ public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary
         final Club club = clubRemoveDataAccessObject.getClub(clubEmail);
 
         // Verify that the student even exists
-        if (!clubRemoveDataAccessObject.existsByEmail(studentEmail)) {
+        if (!clubRemoveDataAccessObject.existsByEmailStudent(studentEmail)) {
             clubRemovePresenter.prepareFailView(studentEmail + ": Account does not exist.");
         }
         else {

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberUserDataAccessInterface.java
@@ -24,6 +24,7 @@ public interface ClubRemoveMemberUserDataAccessInterface {
 
     /**
      * Return student with given username. Make sure to check that the student exists.
+     * Precondition: The student must exist.
      * @param studentEmail student's username
      * @return the student with given username
      */

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberUserDataAccessInterface.java
@@ -17,10 +17,10 @@ public interface ClubRemoveMemberUserDataAccessInterface {
 
     /**
      * Checks if the student with given username exists.
-     * @param studentEmail the username of the student we want to check
+     * @param email the username of the student we want to check
      * @return a boolean. True if the student exists, false else.
      */
-    boolean existsByEmail(String studentEmail);
+    boolean existsByEmailStudent(String email);
 
     /**
      * Return student with given username. Make sure to check that the student exists.

--- a/src/main/java/use_case/login/club_login/ClubLoginDataAccessInterface.java
+++ b/src/main/java/use_case/login/club_login/ClubLoginDataAccessInterface.java
@@ -11,7 +11,7 @@ public interface ClubLoginDataAccessInterface {
      * @param email the email to look for
      * @return true if a Club with the given email exists in the database.
      */
-    boolean existsByEmail(String email);
+    boolean existsByEmailClub(String email);
 
     /**
      * Returns the club with the given email.

--- a/src/main/java/use_case/login/club_login/ClubLoginDataAccessInterface.java
+++ b/src/main/java/use_case/login/club_login/ClubLoginDataAccessInterface.java
@@ -15,6 +15,7 @@ public interface ClubLoginDataAccessInterface {
 
     /**
      * Returns the club with the given email.
+     * Precondition: The club must exist.
      * @param email of the club we are looking for
      * @return the Club with the given email
      */

--- a/src/main/java/use_case/login/club_login/ClubLoginInteractor.java
+++ b/src/main/java/use_case/login/club_login/ClubLoginInteractor.java
@@ -16,13 +16,13 @@ public class ClubLoginInteractor implements ClubLoginInputBoundary {
     }
 
     /**
-     * Executes the login use case for the student user.
+     * Executes the login use case for the club user.
      * @param clubLoginInputData the input data
      */
     public void execute(ClubLoginInputData clubLoginInputData) {
         final String email = clubLoginInputData.getEmail();
         final String password = clubLoginInputData.getPassword();
-        if (!clubDataAccessObject.existsByEmail(email)) {
+        if (!clubDataAccessObject.existsByEmailClub(email)) {
             clubLoginPresenter.prepareFailView(email + ": Account does not exist.");
         }
         else {

--- a/src/main/java/use_case/login/student_login/StudentLoginDataAccessInterface.java
+++ b/src/main/java/use_case/login/student_login/StudentLoginDataAccessInterface.java
@@ -9,10 +9,10 @@ public interface StudentLoginDataAccessInterface {
 
     /**
     * Checks if the given student email exists in the database.
-    * @param studentEmail the student email to look for
+    * @param email the student email to look for
     * @return true if a Student with the given student email exists in the database.
      */
-    boolean existsByEmail(String studentEmail);
+    boolean existsByEmailStudent(String email);
 
     /**
      * Returns the student with the given email.

--- a/src/main/java/use_case/login/student_login/StudentLoginDataAccessInterface.java
+++ b/src/main/java/use_case/login/student_login/StudentLoginDataAccessInterface.java
@@ -16,6 +16,7 @@ public interface StudentLoginDataAccessInterface {
 
     /**
      * Returns the student with the given email.
+     * Precondition: The student must exist.
      * @param studentEmail of the student we are looking for
      * @return the student with the given studentEmail
      */

--- a/src/main/java/use_case/login/student_login/StudentLoginInteractor.java
+++ b/src/main/java/use_case/login/student_login/StudentLoginInteractor.java
@@ -22,7 +22,7 @@ public class StudentLoginInteractor implements StudentLoginInputBoundary {
     public void execute(StudentLoginInputData studentLoginInputData) {
         final String studentEmail = studentLoginInputData.getStudentEmail();
         final String password = studentLoginInputData.getPassword();
-        if (!studentDataAccessObject.existsByEmail(studentEmail)) {
+        if (!studentDataAccessObject.existsByEmailStudent(studentEmail)) {
             studentLoginPresenter.prepareFailView(studentEmail + ": Account does not exist.");
         }
         else {

--- a/src/main/java/use_case/signup/club_signup/ClubSignupInteractor.java
+++ b/src/main/java/use_case/signup/club_signup/ClubSignupInteractor.java
@@ -21,10 +21,10 @@ public class ClubSignupInteractor implements ClubSignupInputBoundary {
 
     @Override
     public void execute(ClubSignupInputData clubSignupInputData) {
-        if (userDataAccessObject.existsByName(clubSignupInputData.getUsername())) {
+        if (userDataAccessObject.existsByNameClub(clubSignupInputData.getUsername())) {
             userPresenter.prepareFailView("Username already exists.");
         }
-        else if (userDataAccessObject.existsByEmail(clubSignupInputData.getEmail())) {
+        else if (userDataAccessObject.existsByEmailClub(clubSignupInputData.getEmail())) {
             userPresenter.prepareFailView("Email address already exists.");
         }
         else if (!clubSignupInputData.getPassword().equals(clubSignupInputData.getRepeatPassword())) {

--- a/src/main/java/use_case/signup/club_signup/ClubSignupUserDataAccessInterface.java
+++ b/src/main/java/use_case/signup/club_signup/ClubSignupUserDataAccessInterface.java
@@ -1,6 +1,6 @@
 package use_case.signup.club_signup;
 
-import entity.user.User;
+import entity.user.Club;
 
 /**
  * DAO for the Club Signup Use Case.
@@ -25,5 +25,5 @@ public interface ClubSignupUserDataAccessInterface {
      * Saves the club user.
      * @param user the club user to save
      */
-    void saveClub(User user);
+    void saveClub(Club user);
 }

--- a/src/main/java/use_case/signup/club_signup/ClubSignupUserDataAccessInterface.java
+++ b/src/main/java/use_case/signup/club_signup/ClubSignupUserDataAccessInterface.java
@@ -12,14 +12,14 @@ public interface ClubSignupUserDataAccessInterface {
      * @param username the username to look for
      * @return true if a user with the given username exists; false otherwise
      */
-    boolean existsByName(String username);
+    boolean existsByNameClub(String username);
 
     /**
      * Checks if the given email exists.
      * @param email the email to look for
      * @return true if a user with the given email exists; false otherwise
      */
-    boolean existsByEmail(String email);
+    boolean existsByEmailClub(String email);
 
     /**
      * Saves the club user.

--- a/src/main/java/use_case/signup/student_signup/StudentSignupInteractor.java
+++ b/src/main/java/use_case/signup/student_signup/StudentSignupInteractor.java
@@ -21,10 +21,10 @@ public class StudentSignupInteractor implements StudentSignupInputBoundary {
 
     @Override
     public void execute(StudentSignupInputData studentSignupInputData) {
-        if (userDataAccessObject.existsByName(studentSignupInputData.getUsername())) {
+        if (userDataAccessObject.existsByNameStudent(studentSignupInputData.getUsername())) {
             userPresenter.prepareFailView("Username already exists.");
         }
-        else if (userDataAccessObject.existsByEmail(studentSignupInputData.getEmail())) {
+        else if (userDataAccessObject.existsByEmailStudent(studentSignupInputData.getEmail())) {
             userPresenter.prepareFailView("Email address already exists.");
         }
         else if (!studentSignupInputData.getPassword().equals(studentSignupInputData.getRepeatPassword())) {

--- a/src/main/java/use_case/signup/student_signup/StudentSignupUserDataAccessInterface.java
+++ b/src/main/java/use_case/signup/student_signup/StudentSignupUserDataAccessInterface.java
@@ -1,6 +1,6 @@
 package use_case.signup.student_signup;
 
-import entity.user.User;
+import entity.user.Student;
 
 /**
  * DAO for the Student Signup Use Case.
@@ -25,6 +25,6 @@ public interface StudentSignupUserDataAccessInterface {
      * Saves the student user.
      * @param user the student user to save
      */
-    void saveStudent(User user);
+    void saveStudent(Student user);
 
 }

--- a/src/main/java/use_case/signup/student_signup/StudentSignupUserDataAccessInterface.java
+++ b/src/main/java/use_case/signup/student_signup/StudentSignupUserDataAccessInterface.java
@@ -12,14 +12,14 @@ public interface StudentSignupUserDataAccessInterface {
      * @param username the username to look for
      * @return true if a user with the given username exists; false otherwise
      */
-    boolean existsByName(String username);
+    boolean existsByNameStudent(String username);
 
     /**
      * Checks if the given email exists.
      * @param email the email to look for
      * @return true if a user with the given email exists; false otherwise
      */
-    boolean existsByEmail(String email);
+    boolean existsByEmailStudent(String email);
 
     /**
      * Saves the student user.


### PR DESCRIPTION
Why?
When trying to login with club credentials, without checking the club box, the app encountered an error. No error would be displayed on the user views, even though it was wrong.
Similarly with students, if you tried signing up with student credentials and checking the club box, the app would cause and error in the terminal.
The user was never warned of the error, and so the screen would remain the same even after causing it.

What changed?
I split the existsByEmail and existsByName each into two separate methods respectively for students and clubs. This also meant I had to do some further refactoring in the dataAccessInterface of select use cases. Furthermore, I added specifications in the java docs of some methods in the form of preconditions, to ensure that the user doesn't use the methods on unexpected inputs.
Finally, I revamped the in memory DAO methods to work with the new changes. 

Did I respect CA/SOLID principles?
YES! With all these changes, I made sure to add the necessary abstractions between the use case layer and the data access layer, hence abiding to the CA principles. Moreover, I eliminated all interdependencies, enabling us to expand the code base in the future without having to worry about other parts of the code being affected (Open/Closed and Liskov principles).

Additional information:
Since Kabir will work on the firestore database DAO, I decided to comment out all the pre-existing code in that file in order to not cause any errors. As this will be implemented in the near future, this shouldn't be a problem for now as the app runs on the in memory DAO .

Contributor: Karl