### PR TITLE
Firestore changes

### DIFF
--- a/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
@@ -1,0 +1,145 @@
+package data_access;
+
+import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.firestore.*;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.cloud.FirestoreClient;
+import entity.post.Post;
+import entity.user.Club;
+import entity.user.Student;
+import use_case.club_create_post.ClubCreatePostUserDataAccessInterface;
+import use_case.club_get_members.ClubGetMembersUserDataAccessInterface;
+import use_case.club_remove_member.ClubRemoveMemberClubDataAccessInterface;
+import use_case.club_remove_member.ClubRemoveMemberStudentDataAccessInterface;
+import use_case.login.club_login.ClubLoginDataAccessInterface;
+import use_case.login.student_login.StudentLoginDataAccessInterface;
+import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
+import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
+import use_case.student_join_club.StudentJoinClubAccessInterface;
+import use_case.student_leave_club.StudentLeaveClubAccessInterface;
+import use_case.student_search_club.StudentSearchClubAccessInterface;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Persisting memory implementation of the DAO for storing user data.
+ * This implementation uses Firebase and only persists data regarding the
+ * Student entity
+ */
+public class ClubFirestoreUserDataAccessObject implements ClubCreatePostUserDataAccessInterface,
+        ClubGetMembersUserDataAccessInterface, ClubRemoveMemberClubDataAccessInterface, ClubLoginDataAccessInterface,
+        ClubSignupUserDataAccessInterface {
+    private final Firestore db;
+    private final String clubs = "clubs";
+    private final String usernames = "username";
+
+    public ClubFirestoreUserDataAccessObject() throws IOException {
+        // TODO fix this to be environment variable
+        final FileInputStream serviceAccount =
+                new FileInputStream("/ServiceAccountKey.json");
+
+        final FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+        this.db = FirestoreClient.getFirestore();
+    }
+
+    @Override
+    public boolean existsByNameClub(String username) {
+        final ApiFuture<QuerySnapshot> future = db.collection(clubs).whereEqualTo(usernames, username).get();
+        boolean returnValue;
+        try {
+            returnValue = !future.get().isEmpty();
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            // Handle exceptions appropriately
+            ex.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByEmailClub(String email) {
+        final DocumentReference docRef = db.collection(clubs).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        boolean returnValue;
+        try {
+            final DocumentSnapshot document = future.get();
+            returnValue = document.exists();
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            // Handle exceptions appropriately
+            ex.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public void saveClub(Club user) {
+        final DocumentReference docRef = db.collection(clubs).document(user.getEmail());
+        final ApiFuture<WriteResult> writeResult = docRef.set(user);
+        try {
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            // Handle exceptions appropriately
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void savePost(Post post, Club club) {
+        // same implementation as saveClub
+        // method overwrites the club data including the new post.
+        final DocumentReference docRef = db.collection(clubs).document(club.getEmail());
+        final ApiFuture<WriteResult> writeResult = docRef.set(club);
+        try {
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            // Handle exceptions appropriately
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public Club getClub(String email) {
+        // get student through email
+        final DocumentReference docRef = db.collection(clubs).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        Club returnValue = null;
+        try {
+            final DocumentSnapshot document = future.get();
+            if (document.exists()) {
+                returnValue = document.toObject(Club.class);
+            }
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            ex.printStackTrace();
+        }
+        return returnValue;
+    }
+
+    @Override
+    public void updateClubMembers(Club club) {
+        // same implementation as saveClub
+        // method overwrites the club data including the updated student list.
+        final DocumentReference docRef = db.collection(clubs).document(club.getEmail());
+        final ApiFuture<WriteResult> writeResult = docRef.set(club);
+        try {
+            System.out.println("Update time: " + writeResult.get().getUpdateTime());
+        }
+        catch (InterruptedException | ExecutionException ex) {
+            // Handle exceptions appropriately
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/data_access/FirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FirestoreUserDataAccessObject.java
@@ -1,167 +1,168 @@
-package data_access;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.firestore.*;
-
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
-
-import com.google.api.core.ApiFuture;
-import com.google.firebase.cloud.FirestoreClient;
-
-
-import entity.user.*;
-import use_case.login.club_login.ClubLoginDataAccessInterface;
-import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
-import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
-import use_case.login.student_login.StudentLoginDataAccessInterface;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
-/**
- * Persisting memory implementation of the DAO for storing user data
- * This implementation uses Firebase
- */
-public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
-    StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
-    private final Firestore db;
-    private final String students = "students";
-    private final String clubs = "clubs";
-    private final String emails = "email";
-
-    public FirestoreUserDataAccessObject() throws IOException {
-        // TODO fix this to be environment variable
-        final FileInputStream serviceAccount =
-                new FileInputStream("/ServiceAccountKey.json");
-
-        final FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        FirebaseApp.initializeApp(options);
-        this.db = FirestoreClient.getFirestore();
-    }
-
-    @Override
-    public Student getStudent(String email) {
-        final DocumentReference docRef = db.collection(students).document(email);
-        final ApiFuture<DocumentSnapshot> future = docRef.get();
-        Student returnValue = null;
-        try {
-            final DocumentSnapshot document = future.get();
-            if (document.exists()) {
-                returnValue = document.toObject(Student.class);
-            }
-        }
-        catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-        }
-        return returnValue;
-    }
-
-    @Override
-    public Club getClub(String email) {
-        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
-        try {
-            QuerySnapshot documents = future.get();
-            if (!documents.isEmpty()) {
-                DocumentSnapshot document = documents.getDocuments().get(0);
-                return document.toObject(Club.class);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    @Override
-    public boolean existsByNameStudent(String username) {
-        final DocumentReference docRef = db.collection(students).document(username);
-        final ApiFuture<DocumentSnapshot> future = docRef.get();
-        boolean returnValue;
-        try {
-            final DocumentSnapshot document = future.get();
-            returnValue = document.exists();
-        }
-        catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            returnValue = false;
-        }
-        return returnValue;
-    }
-
-    @Override
-    public boolean existsByNameClub(String username) {
-        final DocumentReference docRef = db.collection(clubs).document(username);
-        final ApiFuture<DocumentSnapshot> future = docRef.get();
-        boolean returnValue;
-        try {
-            final DocumentSnapshot document = future.get();
-            returnValue = document.exists();
-        }
-        catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            returnValue = false;
-        }
-        return returnValue;
-    }
-
-    @Override
-    public boolean existsByEmailStudent(String email) {
-        final ApiFuture<QuerySnapshot> future = db.collection(students).whereEqualTo(emails, email).get();
-        boolean returnValue;
-        try {
-            returnValue = !future.get().isEmpty();
-        }
-        catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            returnValue = false;
-        }
-        return returnValue;
-    }
-
-    @Override
-    public boolean existsByEmailClub(String email) {
-        final ApiFuture<QuerySnapshot> future = db.collection(clubs).whereEqualTo(emails, email).get();
-        boolean returnValue;
-        try {
-            returnValue = !future.get().isEmpty();
-        }
-        catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-            returnValue = false;
-        }
-        return returnValue;
-    }
-
-    @Override
-    public void saveStudent(Student user) {
-        DocumentReference docRef = db.collection(students).document(user.getEmail());
-        ApiFuture<WriteResult> writeResult = docRef.set(user);
-        try {
-            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-        }
-    }
-
-    @Override
-    public void saveClub(Club user) {
-        DocumentReference docRef = db.collection("users").document(user.getUsername());
-        ApiFuture<WriteResult> writeResult = docRef.set(user);
-        try {
-            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-        } catch (InterruptedException | ExecutionException e) {
-            // Handle exceptions appropriately
-            e.printStackTrace();
-        }
-    }
-
-}
+//package data_access;
+//
+//import com.google.auth.oauth2.GoogleCredentials;
+//import com.google.cloud.firestore.*;
+//
+//import com.google.firebase.FirebaseApp;
+//import com.google.firebase.FirebaseOptions;
+//
+//import com.google.api.core.ApiFuture;
+//import com.google.firebase.cloud.FirestoreClient;
+//
+//
+//import entity.user.*;
+//import use_case.login.club_login.ClubLoginDataAccessInterface;
+//import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
+//import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
+//import use_case.login.student_login.StudentLoginDataAccessInterface;
+//
+//import java.io.FileInputStream;
+//import java.io.IOException;
+//import java.util.concurrent.ExecutionException;
+//
+///**
+// * Persisting memory implementation of the DAO for storing user data
+// * This implementation uses Firebase
+// */
+//public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
+//    StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
+//    private final Firestore db;
+//    private final String students = "students";
+//    private final String clubs = "clubs";
+//    private final String emails = "email";
+//
+//    public FirestoreUserDataAccessObject() throws IOException {
+//        // TODO fix this to be environment variable
+//        final FileInputStream serviceAccount =
+//                new FileInputStream("/ServiceAccountKey.json");
+//
+//        final FirebaseOptions options = new FirebaseOptions.Builder()
+//                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+//                .build();
+//
+//        FirebaseApp.initializeApp(options);
+//        this.db = FirestoreClient.getFirestore();
+//    }
+//
+//    @Override
+//    public Student getStudent(String email) {
+//        final DocumentReference docRef = db.collection(students).document(email);
+//        final ApiFuture<DocumentSnapshot> future = docRef.get();
+//        Student returnValue = null;
+//        try {
+//            final DocumentSnapshot document = future.get();
+//            if (document.exists()) {
+//                returnValue = document.toObject(Student.class);
+//            }
+//        }
+//        catch (InterruptedException | ExecutionException e) {
+//            e.printStackTrace();
+//        }
+//        return returnValue;
+//    }
+//
+//    @Override
+//    public Club getClub(String email) {
+//        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
+//        try {
+//            QuerySnapshot documents = future.get();
+//            if (!documents.isEmpty()) {
+//                DocumentSnapshot document = documents.getDocuments().get(0);
+//                return document.toObject(Club.class);
+//            }
+//        } catch (InterruptedException | ExecutionException e) {
+//            e.printStackTrace();
+//        }
+//        return null;
+//    }
+//
+//    @Override
+//    public boolean existsByNameStudent(String username) {
+//        final DocumentReference docRef = db.collection(students).document(username);
+//        final ApiFuture<DocumentSnapshot> future = docRef.get();
+//        boolean returnValue;
+//        try {
+//            final DocumentSnapshot document = future.get();
+//            returnValue = document.exists();
+//        }
+//        catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            returnValue = false;
+//        }
+//        return returnValue;
+//    }
+//
+//    @Override
+//    public boolean existsByNameClub(String username) {
+//        final DocumentReference docRef = db.collection(clubs).document(username);
+//        final ApiFuture<DocumentSnapshot> future = docRef.get();
+//        boolean returnValue;
+//        try {
+//            final DocumentSnapshot document = future.get();
+//            returnValue = document.exists();
+//        }
+//        catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            returnValue = false;
+//        }
+//        return returnValue;
+//    }
+//
+//    @Override
+//    public boolean existsByEmailStudent(String email) {
+//        final ApiFuture<QuerySnapshot> future = db.collection(students).whereEqualTo(emails, email).get();
+//        boolean returnValue;
+//        try {
+//            returnValue = !future.get().isEmpty();
+//        }
+//        catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            returnValue = false;
+//        }
+//        return returnValue;
+//    }
+//
+//    @Override
+//    public boolean existsByEmailClub(String email) {
+//        final ApiFuture<QuerySnapshot> future = db.collection(clubs).whereEqualTo(emails, email).get();
+//        boolean returnValue;
+//        try {
+//            returnValue = !future.get().isEmpty();
+//        }
+//        catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//            returnValue = false;
+//        }
+//        return returnValue;
+//    }
+//
+//    @Override
+//    public void saveStudent(Student user) {
+//        final DocumentReference docRef = db.collection(students).document(user.getEmail());
+//        final ApiFuture<WriteResult> writeResult = docRef.set(user);
+//        try {
+//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+//        }
+//        catch (InterruptedException | ExecutionException ex) {
+//            // Handle exceptions appropriately
+//            ex.printStackTrace();
+//        }
+//    }
+//
+//    @Override
+//    public void saveClub(Club user) {
+//        final DocumentReference docRef = db.collection("users").document(user.getUsername());
+//        final ApiFuture<WriteResult> writeResult = docRef.set(user);
+//        try {
+//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+//        } catch (InterruptedException | ExecutionException e) {
+//            // Handle exceptions appropriately
+//            e.printStackTrace();
+//        }
+//    }
+//
+//}

--- a/src/main/java/data_access/FirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/FirestoreUserDataAccessObject.java
@@ -1,124 +1,167 @@
-//package data_access;
-//
-//import com.google.auth.oauth2.GoogleCredentials;
-//import com.google.cloud.firestore.*;
-//
-//import com.google.firebase.FirebaseApp;
-//import com.google.firebase.FirebaseOptions;
-//
-//import com.google.api.core.ApiFuture;
-//import com.google.firebase.cloud.FirestoreClient;
-//import com.google.firebase.cloud.StorageClient;
-//
-//
-//import entity.user.*;
-//import use_case.login.club_login.ClubLoginDataAccessInterface;
-//import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
-//import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
-//import use_case.login.student_login.StudentLoginDataAccessInterface;
-//
-//import java.io.FileInputStream;
-//import java.io.IOException;
-//import java.util.concurrent.ExecutionException;
-//
-///**
-// * Persisting memory implementation of the DAO for storing user data
-// * This implementation uses Firebase
-// */
-//public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
-//StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
-//    private final Firestore db;
-//
-//    public FirestoreUserDataAccessObject() throws IOException {
-//        // TODO fix this to be environment variable
-//        FileInputStream serviceAccount =
-//                new FileInputStream("/ServiceAccountKey.json");
-//
-//        FirebaseOptions options = new FirebaseOptions.Builder()
-//                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-//                .build();
-//
-//        FirebaseApp.initializeApp(options);
-//        this.db = FirestoreClient.getFirestore();
-//    }
-//
-//    @Override
-//    public boolean existsByName(String username) {
-//        DocumentReference docRef = db.collection("users").document(username);
-//        ApiFuture<DocumentSnapshot> future = docRef.get();
-//        try {
-//            DocumentSnapshot document = future.get();
-//            return document.exists();
-//        } catch (InterruptedException | ExecutionException e) {
-//            // Handle exceptions appropriately
-//            e.printStackTrace();
-//            return false;
-//        }
-//    }
-//
-//    @Override
-//    public Student getStudent(String username) {
-//        DocumentReference docRef = db.collection("users").document(username);
-//        ApiFuture<DocumentSnapshot> future = docRef.get();
-//        try {
-//            DocumentSnapshot document = future.get();
-//            if (document.exists()) {
-//                return document.toObject(Student.class);
-//            }
-//        } catch (InterruptedException | ExecutionException e) {
-//            e.printStackTrace();
-//        }
-//        return null; // Return null if no student is found
-//    }
-//
-//    @Override
-//    public boolean existsByEmail(String email) {
-//        ApiFuture<QuerySnapshot> future = db.collection("users").whereEqualTo("email", email).get();
-//        try {
-//            return !future.get().isEmpty();
-//        } catch (InterruptedException | ExecutionException e) {
-//            // Handle exceptions appropriately
-//            e.printStackTrace();
-//            return false;
-//        }
-//    }
-//
-//    @Override
-//    public void saveStudent(Student user) {
-//        DocumentReference docRef = db.collection("users").document(user.getUsername());
-//        ApiFuture<WriteResult> writeResult = docRef.set(user);
-//        try {
-//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-//        } catch (InterruptedException | ExecutionException e) {
-//            // Handle exceptions appropriately
-//            e.printStackTrace();
-//        }
-//    }
-//
-//    @Override
-//    public void saveClub(Club user) {
-//        DocumentReference docRef = db.collection("users").document(user.getUsername());
-//        ApiFuture<WriteResult> writeResult = docRef.set(user);
-//        try {
-//            System.out.println("Update time : " + writeResult.get().getUpdateTime());
-//        } catch (InterruptedException | ExecutionException e) {
-//            // Handle exceptions appropriately
-//            e.printStackTrace();
-//        }
-//    }
-//
-//    @Override
-//    public Club getClub(String email) {
-//        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
-//        try {
-//            QuerySnapshot documents = future.get();
-//            if (!documents.isEmpty()) {
-//                DocumentSnapshot document = documents.getDocuments().get(0);
-//                return document.toObject(Club.class);
-//            }
-//        } catch (InterruptedException | ExecutionException e) {
-//            e.printStackTrace();
-//        }
-//        return null; // Return null if no club is found
-//    }
-//}
+package data_access;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.firestore.*;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+import com.google.api.core.ApiFuture;
+import com.google.firebase.cloud.FirestoreClient;
+
+
+import entity.user.*;
+import use_case.login.club_login.ClubLoginDataAccessInterface;
+import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
+import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
+import use_case.login.student_login.StudentLoginDataAccessInterface;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Persisting memory implementation of the DAO for storing user data
+ * This implementation uses Firebase
+ */
+public class FirestoreUserDataAccessObject implements ClubLoginDataAccessInterface, ClubSignupUserDataAccessInterface,
+    StudentSignupUserDataAccessInterface, StudentLoginDataAccessInterface {
+    private final Firestore db;
+    private final String students = "students";
+    private final String clubs = "clubs";
+    private final String emails = "email";
+
+    public FirestoreUserDataAccessObject() throws IOException {
+        // TODO fix this to be environment variable
+        final FileInputStream serviceAccount =
+                new FileInputStream("/ServiceAccountKey.json");
+
+        final FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+        this.db = FirestoreClient.getFirestore();
+    }
+
+    @Override
+    public Student getStudent(String email) {
+        final DocumentReference docRef = db.collection(students).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        Student returnValue = null;
+        try {
+            final DocumentSnapshot document = future.get();
+            if (document.exists()) {
+                returnValue = document.toObject(Student.class);
+            }
+        }
+        catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return returnValue;
+    }
+
+    @Override
+    public Club getClub(String email) {
+        ApiFuture<QuerySnapshot> future = db.collection("clubs").whereEqualTo("email", email).get();
+        try {
+            QuerySnapshot documents = future.get();
+            if (!documents.isEmpty()) {
+                DocumentSnapshot document = documents.getDocuments().get(0);
+                return document.toObject(Club.class);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean existsByNameStudent(String username) {
+        final DocumentReference docRef = db.collection(students).document(username);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        boolean returnValue;
+        try {
+            final DocumentSnapshot document = future.get();
+            returnValue = document.exists();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByNameClub(String username) {
+        final DocumentReference docRef = db.collection(clubs).document(username);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        boolean returnValue;
+        try {
+            final DocumentSnapshot document = future.get();
+            returnValue = document.exists();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByEmailStudent(String email) {
+        final ApiFuture<QuerySnapshot> future = db.collection(students).whereEqualTo(emails, email).get();
+        boolean returnValue;
+        try {
+            returnValue = !future.get().isEmpty();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByEmailClub(String email) {
+        final ApiFuture<QuerySnapshot> future = db.collection(clubs).whereEqualTo(emails, email).get();
+        boolean returnValue;
+        try {
+            returnValue = !future.get().isEmpty();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public void saveStudent(Student user) {
+        DocumentReference docRef = db.collection(students).document(user.getEmail());
+        ApiFuture<WriteResult> writeResult = docRef.set(user);
+        try {
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+        } catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void saveClub(Club user) {
+        DocumentReference docRef = db.collection("users").document(user.getUsername());
+        ApiFuture<WriteResult> writeResult = docRef.set(user);
+        try {
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+        } catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
@@ -1,0 +1,130 @@
+package data_access;
+
+import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.firestore.*;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.cloud.FirestoreClient;
+import entity.user.Club;
+import entity.user.Student;
+import use_case.club_remove_member.ClubRemoveMemberStudentDataAccessInterface;
+import use_case.login.club_login.ClubLoginDataAccessInterface;
+import use_case.login.student_login.StudentLoginDataAccessInterface;
+import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
+import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
+import use_case.student_join_club.StudentJoinClubAccessInterface;
+import use_case.student_leave_club.StudentLeaveClubAccessInterface;
+import use_case.student_search_club.StudentSearchClubAccessInterface;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Persisting memory implementation of the DAO for storing user data
+ * This implementation uses Firebase and only persists data regarding the
+ * Student entity
+ */
+public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAccessInterface,
+        StudentSignupUserDataAccessInterface, StudentJoinClubAccessInterface,
+        StudentLeaveClubAccessInterface, StudentSearchClubAccessInterface,
+        ClubRemoveMemberStudentDataAccessInterface {
+    private final Firestore db;
+    private final String students = "students";
+    private final String usernames = "username";
+
+    public StudentFirestoreUserDataAccessObject() throws IOException {
+        // TODO fix this to be environment variable
+        final FileInputStream serviceAccount =
+                new FileInputStream("/ServiceAccountKey.json");
+
+        final FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+        this.db = FirestoreClient.getFirestore();
+    }
+
+    @Override
+    public Student getStudent(String email) {
+        // get student through email
+        final DocumentReference docRef = db.collection(students).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        Student returnValue = null;
+        try {
+            final DocumentSnapshot document = future.get();
+            if (document.exists()) {
+                returnValue = document.toObject(Student.class);
+            }
+        }
+        catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByNameStudent(String username) {
+        final ApiFuture<QuerySnapshot> future = db.collection(students).whereEqualTo(usernames, username).get();
+        boolean returnValue;
+        try {
+            returnValue = !future.get().isEmpty();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public boolean existsByEmailStudent(String email) {
+        final DocumentReference docRef = db.collection(students).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        boolean returnValue;
+        try {
+            final DocumentSnapshot document = future.get();
+            returnValue = document.exists();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+            returnValue = false;
+        }
+        return returnValue;
+    }
+
+    @Override
+    public void saveStudent(Student user) {
+        // save students based off their usernames for ID's
+        final DocumentReference docRef = db.collection(students).document(user.getEmail());
+        final ApiFuture<WriteResult> writeResult = docRef.set(user);
+        try {
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
+        }
+        catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void removeClubFromStudent(Student student, Club club) {
+        final String email = student.getEmail();
+        final DocumentReference docRef = db.collection(students).document(email);
+        final ApiFuture<DocumentSnapshot> future = docRef.get();
+
+        try {
+            final DocumentSnapshot document = future.get();
+            if (document.exists()) {
+                docRef.set(student);
+            }
+        }
+        catch (InterruptedException | ExecutionException e) {
+            // Handle exceptions appropriately
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
@@ -56,8 +56,8 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
                 returnValue = document.toObject(Student.class);
             }
         }
-        catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+        catch (InterruptedException | ExecutionException ex) {
+            ex.printStackTrace();
         }
         return returnValue;
     }
@@ -69,9 +69,9 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
         try {
             returnValue = !future.get().isEmpty();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException | ExecutionException ex) {
             // Handle exceptions appropriately
-            e.printStackTrace();
+            ex.printStackTrace();
             returnValue = false;
         }
         return returnValue;
@@ -86,9 +86,9 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
             final DocumentSnapshot document = future.get();
             returnValue = document.exists();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException | ExecutionException ex) {
             // Handle exceptions appropriately
-            e.printStackTrace();
+            ex.printStackTrace();
             returnValue = false;
         }
         return returnValue;
@@ -102,8 +102,8 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
         try {
             System.out.println("Update time : " + writeResult.get().getUpdateTime());
         }
-        catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+        catch (InterruptedException | ExecutionException ex) {
+            ex.printStackTrace();
         }
     }
 
@@ -118,9 +118,9 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
         try {
             System.out.println("Update time : " + writeResult.get().getUpdateTime());
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException | ExecutionException ex) {
             // Handle exceptions appropriately
-            e.printStackTrace();
+            ex.printStackTrace();
         }
     }
 }

--- a/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
@@ -6,12 +6,9 @@ import com.google.cloud.firestore.*;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.cloud.FirestoreClient;
-import entity.user.Club;
 import entity.user.Student;
 import use_case.club_remove_member.ClubRemoveMemberStudentDataAccessInterface;
-import use_case.login.club_login.ClubLoginDataAccessInterface;
 import use_case.login.student_login.StudentLoginDataAccessInterface;
-import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
 import use_case.signup.student_signup.StudentSignupUserDataAccessInterface;
 import use_case.student_join_club.StudentJoinClubAccessInterface;
 import use_case.student_leave_club.StudentLeaveClubAccessInterface;
@@ -111,16 +108,15 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
     }
 
     @Override
-    public void removeClubFromStudent(Student student, Club club) {
+    public void updateStudentClubsJoined(Student student) {
+        // updates the student clubs joined
+        // very similar to saveStudent
         final String email = student.getEmail();
         final DocumentReference docRef = db.collection(students).document(email);
-        final ApiFuture<DocumentSnapshot> future = docRef.get();
+        final ApiFuture<WriteResult> writeResult = docRef.set(student);
 
         try {
-            final DocumentSnapshot document = future.get();
-            if (document.exists()) {
-                docRef.set(student);
-            }
+            System.out.println("Update time : " + writeResult.get().getUpdateTime());
         }
         catch (InterruptedException | ExecutionException e) {
             // Handle exceptions appropriately

--- a/src/main/java/entity/data_structure/DataStore.java
+++ b/src/main/java/entity/data_structure/DataStore.java
@@ -12,10 +12,11 @@ public interface DataStore<T> {
     void add(T element);
 
     /**
-     * Removes element from data structure.
+     * Removes element from data structure and returns its value.
      * @param element element to remove.
+     * @return element that has been removed.
      */
-    void remove(T element);
+    T remove(T element);
 
     /**
      * Gets element from data structure.
@@ -23,13 +24,6 @@ public interface DataStore<T> {
      * @return returns the element.
      */
     T get(T element);
-
-    /**
-     * Removes and returns the element that has been removed.
-     * @param element element to pop.
-     * @return element that has been popped.
-     */
-    T pop(T element);
 
     /**
      * Returns boolean if an element exists in the data structure.

--- a/src/main/java/entity/data_structure/DataStoreArrays.java
+++ b/src/main/java/entity/data_structure/DataStoreArrays.java
@@ -20,8 +20,9 @@ public class DataStoreArrays<T> implements DataStore<T>, Iterable<T> {
     }
 
     @Override
-    public void remove(T element) {
+    public T remove(T element) {
         data.remove(element);
+        return element;
     }
 
     @Override
@@ -40,20 +41,18 @@ public class DataStoreArrays<T> implements DataStore<T>, Iterable<T> {
      * @param index integer value of index.
      * @return value at index.
      */
-    public T get(int index) {
+    public T getByIndex(int index) {
         return data.get(index);
     }
 
-    @Override
-    public T pop(T element) {
-        T temp = null;
-        for (int i = 0; i < data.size(); i++) {
-            if (data.get(i).equals(element)) {
-                temp = data.get(i);
-                data.remove(i);
-            }
-        }
-        return temp;
+    /**
+     * Removes and returns the last element of the list.
+     * @return element that has been popped.
+     */
+    public T pop() {
+        final T last = data.get(data.size() - 1);
+        data.remove(data.size() - 1);
+        return last;
     }
 
     @Override

--- a/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
@@ -33,8 +33,8 @@ public class ClubCreatePostInteractor implements ClubCreatePostInputBoundary {
                     post.getTitle(), post.getContent(), post.timeOfPosting(), post.dateOfPosting(), false);
             // Get club by email, since the user exists and logged in, we know the email exists for save
             final Club club = createPostDataAccessObject.getClub(clubCreatePostInputData.getEmail());
-            club.addClubPost(post);
 
+            club.addClubPost(post);
             // Save post to database
             createPostDataAccessObject.savePost(post, club);
 

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberClubDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberClubDataAccessInterface.java
@@ -1,0 +1,24 @@
+package use_case.club_remove_member;
+
+import entity.user.Club;
+import entity.user.Student;
+
+/**
+ * Data access interface for club remove member use case.
+ */
+public interface ClubRemoveMemberClubDataAccessInterface {
+
+    /**
+     * Returns club with given email.
+     * @param clubEmail the club's email
+     * @return the club with given email.
+     */
+    Club getClub(String clubEmail);
+
+    /**
+     * Remove the student from the club in the database.
+     * @param student the student that should be removed
+     * @param club the club from which the student needs to be removed from
+     */
+    void removeStudentFromClub(Student student, Club club);
+}

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberClubDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberClubDataAccessInterface.java
@@ -1,7 +1,6 @@
 package use_case.club_remove_member;
 
 import entity.user.Club;
-import entity.user.Student;
 
 /**
  * Data access interface for club remove member use case.
@@ -17,8 +16,8 @@ public interface ClubRemoveMemberClubDataAccessInterface {
 
     /**
      * Remove the student from the club in the database.
-     * @param student the student that should be removed
+     *
      * @param club the club from which the student needs to be removed from
      */
-    void removeStudentFromClub(Student student, Club club);
+    void updateClubMembers(Club club);
 }

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
@@ -42,11 +42,11 @@ public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary
             else {
                 // Remove student from club
                 student.leaveClub(club);
-                clubRemoveStudentDataAccessObject.removeClubFromStudent(student, club);
+                clubRemoveStudentDataAccessObject.updateStudentClubsJoined(student);
 
                 // Remove club from student
                 club.removeClubMember(student);
-                clubRemoveClubDataAccessObject.removeStudentFromClub(student, club);
+                clubRemoveClubDataAccessObject.updateClubMembers(club);
 
                 // Prepare success view
                 final ClubRemoveMemberOutputData outputData = new ClubRemoveMemberOutputData(student.getUsername(),

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
@@ -7,12 +7,15 @@ import entity.user.Student;
  * Interactor for the club remove member use case.
  */
 public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary {
-    private final ClubRemoveMemberUserDataAccessInterface clubRemoveDataAccessObject;
+    private final ClubRemoveMemberStudentDataAccessInterface clubRemoveStudentDataAccessObject;
+    private final ClubRemoveMemberClubDataAccessInterface clubRemoveClubDataAccessObject;
     private final ClubRemoveMemberOutputBoundary clubRemovePresenter;
 
-    public ClubRemoveMemberInteractor(ClubRemoveMemberUserDataAccessInterface clubRemoveDataAccessObject,
+    public ClubRemoveMemberInteractor(ClubRemoveMemberStudentDataAccessInterface clubRemoveStudentDataAccessObject,
+                                      ClubRemoveMemberClubDataAccessInterface clubRemoveClubDataAccessObject,
                                       ClubRemoveMemberOutputBoundary clubRemovePresenter) {
-        this.clubRemoveDataAccessObject = clubRemoveDataAccessObject;
+        this.clubRemoveStudentDataAccessObject = clubRemoveStudentDataAccessObject;
+        this.clubRemoveClubDataAccessObject = clubRemoveClubDataAccessObject;
         this.clubRemovePresenter = clubRemovePresenter;
     }
 
@@ -22,15 +25,15 @@ public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary
         final String clubEmail = inputData.getClubEmail();
 
         // Since we are logged in, the club must exist by precondition, so we do not have to check if the club exists.
-        final Club club = clubRemoveDataAccessObject.getClub(clubEmail);
+        final Club club = clubRemoveClubDataAccessObject.getClub(clubEmail);
 
         // Verify that the student even exists
-        if (!clubRemoveDataAccessObject.existsByEmailStudent(studentEmail)) {
+        if (!clubRemoveStudentDataAccessObject.existsByEmailStudent(studentEmail)) {
             clubRemovePresenter.prepareFailView(studentEmail + ": Account does not exist.");
         }
         else {
             // Get student with same student email
-            final Student student = clubRemoveDataAccessObject.getStudent(studentEmail);
+            final Student student = clubRemoveStudentDataAccessObject.getStudent(studentEmail);
 
             // Verify that student is in club
             if (!club.getClubMembers().contains(student)) {
@@ -38,8 +41,12 @@ public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary
             }
             else {
                 // Remove student from club
-                clubRemoveDataAccessObject.removeStudent(student, club);
+                student.leaveClub(club);
+                clubRemoveStudentDataAccessObject.removeClubFromStudent(student, club);
+
+                // Remove club from student
                 club.removeClubMember(student);
+                clubRemoveClubDataAccessObject.removeStudentFromClub(student, club);
 
                 // Prepare success view
                 final ClubRemoveMemberOutputData outputData = new ClubRemoveMemberOutputData(student.getUsername(),

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberStudentDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberStudentDataAccessInterface.java
@@ -6,14 +6,7 @@ import entity.user.Student;
 /**
  * Data access interface for club remove member use case.
  */
-public interface ClubRemoveMemberUserDataAccessInterface {
-
-    /**
-     * Returns club with given email.
-     * @param clubEmail the club's email
-     * @return the club with given email.
-     */
-    Club getClub(String clubEmail);
+public interface ClubRemoveMemberStudentDataAccessInterface {
 
     /**
      * Checks if the student with given username exists.
@@ -31,9 +24,9 @@ public interface ClubRemoveMemberUserDataAccessInterface {
     Student getStudent(String studentEmail);
 
     /**
-     * Remove the student from the club in the database.
+     * Remove the club from the student in the database.
      * @param student the student that should be removed
      * @param club the club from which the student needs to be removed from
      */
-    void removeStudent(Student student, Club club);
+    void removeClubFromStudent(Student student, Club club);
 }

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberStudentDataAccessInterface.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberStudentDataAccessInterface.java
@@ -1,6 +1,5 @@
 package use_case.club_remove_member;
 
-import entity.user.Club;
 import entity.user.Student;
 
 /**
@@ -25,8 +24,8 @@ public interface ClubRemoveMemberStudentDataAccessInterface {
 
     /**
      * Remove the club from the student in the database.
+     *
      * @param student the student that should be removed
-     * @param club the club from which the student needs to be removed from
      */
-    void removeClubFromStudent(Student student, Club club);
+    void updateStudentClubsJoined(Student student);
 }


### PR DESCRIPTION
What?
Converted the code over from a single DAO over to two DAO's, one for each entity. Also, split up some of methods in Data Access Interfaces into two different DAI's for each entity.

Why?
This fix eliminates the issue of the open closed principle and the single responsibility principle since each DAO only has methods responsible for one single action regarding one entity. Also streamlines and lessens confusion as to which methods do what action for the entities as before the methods all had the same name but performed different tasks.

Let me know what you guys think :)