### PR TITLE
Fix create post and made tests for 100% coverage

### DIFF
--- a/src/main/java/data_access/InMemoryUserDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataAccessObject.java
@@ -124,6 +124,7 @@ public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInt
         for (Club club : clubArrayList) {
             if (club.getEmail().equals(email)) {
                 clubFound = club;
+                break;
             }
         }
         // This should not be returned as null since the precondition states that the club must exist.
@@ -143,6 +144,7 @@ public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInt
         for (Student student : studentArrayList) {
             if (student.getEmail().equals(email)) {
                 foundStudent = student;
+                break;
             }
         }
         // This should not be returned as null since the precondition states that the student must exist.
@@ -160,6 +162,7 @@ public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInt
         for (Club current: clubArrayList) {
             if (current.getUsername().equals(club.getUsername())) {
                 current.addClubPost(post);
+                break;
             }
         }
     }

--- a/src/main/java/interface_adapter/club_logged_in/club_create_post/ClubCreatePostPresenter.java
+++ b/src/main/java/interface_adapter/club_logged_in/club_create_post/ClubCreatePostPresenter.java
@@ -1,6 +1,7 @@
 package interface_adapter.club_logged_in.club_create_post;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.club_logged_in.ClubLoggedInState;
 import interface_adapter.club_logged_in.ClubLoggedInViewModel;
 import use_case.club_create_post.ClubCreatePostOutputBoundary;
 import use_case.club_create_post.ClubCreatePostOutputData;
@@ -26,16 +27,22 @@ public class ClubCreatePostPresenter implements ClubCreatePostOutputBoundary {
      * @param data the output data
      */
     public void prepareSuccessView(ClubCreatePostOutputData data) {
+        final String createPost = "create post";
         final ClubCreatePostState state = clubCreatePostViewModel.getState();
         state.setTimeOfPosting(data.getTimeOfPosting());
         state.setDateOfPosting(data.getDateOfPosting());
         state.setContent(data.getContents());
         state.setTitle(data.getTitle());
         clubCreatePostViewModel.setState(state);
-        clubCreatePostViewModel.firePropertyChanged("create post");
+        clubCreatePostViewModel.firePropertyChanged(createPost);
+
+        final ClubLoggedInState state2 = clubLoggedInViewModel.getState();
+        state2.getPostTitles().add(data.getTitle());
+        state2.getPostBodies().add(data.getContents());
+        clubLoggedInViewModel.firePropertyChanged(createPost);
 
         viewManagerModel.setState(clubCreatePostViewModel.getViewName());
-        viewManagerModel.firePropertyChanged("create post");
+        viewManagerModel.firePropertyChanged(createPost);
     }
 
     /**

--- a/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
@@ -46,7 +46,6 @@ public class ClubCreatePostInteractor implements ClubCreatePostInputBoundary {
             // Get club by email, since the user exists and logged in, we know the email exists for save
             final Club club = createPostDataAccessObject.getClub(clubCreatePostInputData.getEmail());
 
-            club.addClubPost(post);
             // Save post to database
             createPostDataAccessObject.savePost(post, club);
 

--- a/src/main/java/use_case/student_interact/like_and_dislike/StudentLikeInputBoundary.java
+++ b/src/main/java/use_case/student_interact/like_and_dislike/StudentLikeInputBoundary.java
@@ -1,4 +1,0 @@
-package use_case.student_interact.like_and_dislike;
-
-public interface StudentLikeInputBoundary {
-}

--- a/src/main/java/use_case/student_interact/register/StudentRegisterInputBoundary.java
+++ b/src/main/java/use_case/student_interact/register/StudentRegisterInputBoundary.java
@@ -1,4 +1,0 @@
-package use_case.student_interact.register;
-
-public interface StudentRegisterInputBoundary {
-}

--- a/src/main/java/use_case/student_interact/register/StudentRegisterInputData.java
+++ b/src/main/java/use_case/student_interact/register/StudentRegisterInputData.java
@@ -1,4 +1,0 @@
-package use_case.student_interact.register;
-
-public class StudentRegisterInputData {
-}

--- a/src/main/java/view/ClubLoggedInView.java
+++ b/src/main/java/view/ClubLoggedInView.java
@@ -141,6 +141,7 @@ public class ClubLoggedInView extends JPanel implements PropertyChangeListener {
             for (int i = 0; i < postTitles.size(); i++) {
                 final PostTextPanel postPanel = new PostTextPanel(postTitles.get(i), postBodies.get(i));
                 postsScrollPane.add(postPanel);
+                postsScrollPane.validate();
             }
         }
         else if (evt.getPropertyName().equals("get members")) {

--- a/src/test/java/entity/user/ClubTests.java
+++ b/src/test/java/entity/user/ClubTests.java
@@ -1,6 +1,8 @@
 package entity.user;
 
 import entity.data_structure.DataStore;
+import entity.data_structure.DataStoreArrays;
+import entity.post.Announcement;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
@@ -33,6 +35,94 @@ public class ClubTests {
         // Verify that the setter method work
         testClub.setClubDescription("Test Club Description");
         assertEquals("Test Club Description", testClub.getClubDescription());
+
+        // Create other club
+        DataStore<Student> members = new DataStoreArrays<>();
+        DataStore<Post> announcements = new DataStoreArrays<>();
+
+        // Add
+        StudentFactory studentFactory = new StudentUserFactory();
+        members.add(studentFactory.create("test", "test@gmail.com", "test1234"));
+        members.add(studentFactory.create("test2", "test@gmail.com2", "test12342", new DataStoreArrays<>()));
+        PostFactory postFactory = new AnnouncementFactory();
+        announcements.add(postFactory.create("testead", "testead"));
+        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword, members, announcements);
+
+        // Verify
+        assertEquals(clubName, testClub2.getUsername());
+        assertEquals(clubEmail, testClub2.getEmail());
+        assertEquals(clubPassword, testClub2.getPassword());
+        assertEquals("", testClub2.getClubDescription());
+        int sizeMember = testClub2.getClubMembers().size();
+        assertEquals(2, sizeMember);
+        int sizePost = testClub2.getClubPosts().size();
+        assertEquals(1, sizePost);
+    }
+
+    @Test
+    public void testClubMembers() {
+        String studentUsername = "student";
+        String studentEmail = "student@email.com";
+        String studentPassword = "student12345";
+
+        // Initialize the student factory
+        StudentFactory studentFactory = new StudentUserFactory();
+
+        // Create the student
+        Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
+
+        // Verify that the instance variables hold true
+        assertEquals(studentUsername, testStudent.getUsername());
+        assertEquals(studentEmail, testStudent.getEmail());
+        assertEquals(studentPassword, testStudent.getPassword());
+
+        // Create new student
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club testClub = clubFactory.create("test", "test@gmail.com", "test1234");
+        DataStore<Club> members = new DataStoreArrays<>();
+        members.add(testClub);
+        Student newStudent = studentFactory.create(studentUsername, studentEmail, studentPassword, members);
+
+        // Test
+        assertEquals(studentUsername, newStudent.getUsername());
+        assertEquals(studentEmail, newStudent.getEmail());
+        assertEquals(studentPassword, newStudent.getPassword());
+        int sizeJoinedClubs = newStudent.getJoinedClubs().size();
+        assertEquals(1, sizeJoinedClubs);
+
+        // Create the student
+        Student testStudent2 = studentFactory.create(studentUsername, studentEmail, studentPassword);
+
+        // Create 10 clubs for the student to join
+        Club clubToRemove = null;
+        for (int i = 0; i < 10; i++) {
+            Club club = clubFactory.create("club" + i,
+                    "club" + i + "@gmail.com", "password" + i);
+            testStudent2.joinClub(club);
+            clubToRemove = club;
+        }
+
+        // Check that there are 10 clubs joined
+        int sizeClubsJoined = testStudent2.getJoinedClubs().size();
+        assertEquals(10, sizeClubsJoined);
+
+        // Leave club
+        testStudent2.leaveClub(clubToRemove);
+
+        // Check new size
+        int sizeClubsLeave = testStudent2.getJoinedClubs().size();
+        assertEquals(9, sizeClubsLeave);
+
+        // Check the club is no longer in clubs joined
+        DataStore<Club> joinedClubs = testStudent2.getJoinedClubs();
+        int index = 0;
+        while (index < joinedClubs.size()) {
+            // Check that the left club is no longer in the joined clubs by checking the unique username and password
+            Club clubAtIndex = joinedClubs.getByIndex(index);
+            assertNotEquals(clubToRemove.getEmail(), clubAtIndex.getEmail());
+            assertNotEquals(clubToRemove.getUsername(), clubAtIndex.getUsername());
+            index++;
+        }
     }
 
     @Test

--- a/src/test/java/entity/user/StudentTest.java
+++ b/src/test/java/entity/user/StudentTest.java
@@ -1,6 +1,10 @@
 package entity.user;
 
 import entity.data_structure.DataStore;
+import entity.data_structure.DataStoreArrays;
+import entity.post.AnnouncementFactory;
+import entity.post.Post;
+import entity.post.PostFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.*;
@@ -25,6 +29,20 @@ public class StudentTest {
         assertEquals(studentUsername, testStudent.getUsername());
         assertEquals(studentEmail, testStudent.getEmail());
         assertEquals(studentPassword, testStudent.getPassword());
+
+        // Create new student
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club testClub = clubFactory.create("test", "test@gmail.com", "test1234");
+        DataStore<Club> members = new DataStoreArrays<>();
+        members.add(testClub);
+        Student newStudent = studentFactory.create(studentUsername, studentEmail, studentPassword, members);
+
+        // Test
+        assertEquals(studentUsername, newStudent.getUsername());
+        assertEquals(studentEmail, newStudent.getEmail());
+        assertEquals(studentPassword, newStudent.getPassword());
+        int sizeJoinedClubs = newStudent.getJoinedClubs().size();
+        assertEquals(1, sizeJoinedClubs);
     }
 
     @Test
@@ -65,6 +83,129 @@ public class StudentTest {
             assertNotEquals(clubToRemove.getEmail(), clubAtIndex.getEmail());
             assertNotEquals(clubToRemove.getUsername(), clubAtIndex.getUsername());
             index++;
+        }
+    }
+
+    @Test
+    public void testStudentClubManipulation() {
+        String clubName = "Test Club Name";
+        String clubEmail = "club@email.com";
+        String clubPassword = "TestClubPassword123";
+        // Initialize the club factory
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        // Create a Club
+        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Verify that the instance variables are correct
+        assertEquals(clubName, testClub.getUsername());
+        assertEquals(clubEmail, testClub.getEmail());
+        assertEquals(clubPassword, testClub.getPassword());
+        assertEquals("", testClub.getClubDescription());
+
+        // Verify that the setter method work
+        testClub.setClubDescription("Test Club Description");
+        assertEquals("Test Club Description", testClub.getClubDescription());
+
+        // Create other club
+        DataStore<Student> members = new DataStoreArrays<>();
+        DataStore<Post> announcements = new DataStoreArrays<>();
+
+        // Add
+        StudentFactory studentFactory = new StudentUserFactory();
+        members.add(studentFactory.create("test", "test@gmail.com", "test1234"));
+        members.add(studentFactory.create("test2", "test@gmail.com2", "test12342", new DataStoreArrays<>()));
+        PostFactory postFactory = new AnnouncementFactory();
+        announcements.add(postFactory.create("testead", "testead"));
+        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword, members, announcements);
+
+        // Verify
+        assertEquals(clubName, testClub2.getUsername());
+        assertEquals(clubEmail, testClub2.getEmail());
+        assertEquals(clubPassword, testClub2.getPassword());
+        assertEquals("", testClub2.getClubDescription());
+        int sizeMember = testClub2.getClubMembers().size();
+        assertEquals(2, sizeMember);
+        int sizePost = testClub2.getClubPosts().size();
+        assertEquals(1, sizePost);
+    }
+
+    @Test
+    public void testStudentPostManipulation() {
+        String clubName = "Test Club Name";
+        String clubEmail = "club@email.com";
+        String clubPassword = "TestClubPassword123";
+
+        // Initialize the club factory
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        // Create a Club
+        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Test the members
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student studentToRemove = null;
+        for (int i = 0; i < 10; i++) {
+            Student student = studentFactory.create("member" + i, "member" + i +"@gmail.com",
+                    "password" + i);
+            testClub.addClubMember(student);
+            studentToRemove = student;
+        }
+        // Check that there are 10 members
+        int sizeMembers = testClub.getClubMembers().size();
+        assertEquals(10, sizeMembers);
+
+        // Remove Student
+        testClub.removeClubMember(studentToRemove);
+
+        // Check new size
+        int sizeMembersAfterRemove = testClub.getClubMembers().size();
+        assertEquals(9, sizeMembersAfterRemove);
+
+        // Check if member is out
+        DataStore<Student> members = testClub.getClubMembers();
+        int index = 0;
+        while (index < members.size()) {
+            Student studentAtIndex = members.getByIndex(index);
+            // Check for name and password since they are in theory unique.
+            assertNotEquals(studentToRemove.getEmail(), studentAtIndex.getEmail());
+            assertNotEquals(studentToRemove.getUsername(), studentAtIndex.getUsername());
+            index++;
+        }
+
+        // Create a Club
+        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Create 10 club posts
+        PostFactory postFactory = new AnnouncementFactory();
+        Post postToRemove = null;
+        for (int i = 0; i < 10; i++) {
+            Post post = postFactory.create("post" + i, "description" + i);
+            testClub2.addClubPost(post);
+            postToRemove = post;
+        }
+
+        // Check that there are 10 posts
+        int sizePosts = testClub2.getClubPosts().size();
+        assertEquals(10, sizePosts);
+
+        // Remove post
+        testClub2.removeClubPost(postToRemove);
+
+        // Check new size
+        int sizePostsAfterRemove = testClub2.getClubPosts().size();
+        assertEquals(9, sizePostsAfterRemove);
+
+        // Check if post is out
+        DataStore<Post> posts = testClub2.getClubPosts();
+        int index2 = 0;
+        while (index2 < posts.size()) {
+            Post postAtIndex = posts.getByIndex(index2);
+
+            // Verify that no posts has the same exact title and description
+            assertTrue(!postToRemove.getTitle().equals(postAtIndex.getTitle()) &&
+                    !postToRemove.getContent().equals(postAtIndex.getContent()));
+            index2++;
         }
     }
 }

--- a/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
+++ b/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
@@ -6,8 +6,9 @@ import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests for the club create post use case interactor.
@@ -28,22 +29,29 @@ public class ClubCreatePostInteractorTest {
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
         InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
+
+        // Save the club to the in memory DAO/Database
+        userRepository.saveClub(testClub);
+
         final String postTitle = "Test Post Title";
         final String postDescription = "Test Post Description";
 
         // Create the input data for create post use case.
-        ClubCreatePostInputData inputData = new ClubCreatePostInputData(clubEmail, postTitle, postDescription);
+        ArrayList<ClubCreatePostInputData> inputs = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ClubCreatePostInputData inputData = new ClubCreatePostInputData(clubEmail, postTitle + i,
+                    postDescription + i);
+            inputs.add(inputData);
 
-        // Save the club to the in memory DAO/Database
-        userRepository.saveClub(testClub);
+        }
 
         // Create the successPresenter that tests whether the test case is as we expect.
         ClubCreatePostOutputBoundary successPresenter = new ClubCreatePostOutputBoundary() {
             @Override
             public void prepareSuccessView(ClubCreatePostOutputData outputData) {
                 assertEquals(false, outputData.useCaseFailed());
-                assertEquals(outputData.getTitle(), postTitle);
-                assertEquals(outputData.getContents(), postDescription);
+                assertTrue(!outputData.getTitle().equals(postTitle)
+                        && !outputData.getContents().equals(postDescription));
             }
 
             @Override
@@ -53,18 +61,108 @@ public class ClubCreatePostInteractorTest {
 
             @Override
             public void switchToCreatePostView() {
-                // This is expected since we are just switching views.
+                fail("Shouldn't run this.");
             }
 
             @Override
             public void switchToClubLoggedInView() {
-                // This is expected since we are just switching views.
+                fail("Shouldn't run this.");
             }
         };
 
         // Execute the use case that need to be tested.
         ClubCreatePostInputBoundary interactor = new ClubCreatePostInteractor(userRepository, successPresenter);
-        interactor.execute(inputData);
+        for (ClubCreatePostInputData inputData : inputs) {
+            interactor.execute(inputData);
+        }
+        int sizePosts = userRepository.getClub(testClub.getEmail()).getClubPosts().size();
+        assertEquals(10, sizePosts);
+    }
+
+    @Test
+    public void successTestSwitchCreatePostView() {
+        // Initialise the club factory.
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        // Create the club
+        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Initialise the DAO. In our case, we will the in memory DAO for tests.
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+
+
+        // Save the club to the in memory DAO/Database
+        userRepository.saveClub(testClub);
+
+        // Create the successPresenter that tests whether the test case is as we expect.
+        ClubCreatePostOutputBoundary successPresenter = new ClubCreatePostOutputBoundary() {
+            @Override
+            public void prepareSuccessView(ClubCreatePostOutputData outputData) {
+                fail("Shouldn't run this");
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail(errorMessage);
+            }
+
+            @Override
+            public void switchToCreatePostView() {
+                // This is expected since we are just switching views. This will always be true
+            }
+
+            @Override
+            public void switchToClubLoggedInView() {
+                fail("Shouldn't run this");
+            }
+        };
+
+        // Execute the use case that need to be tested.
+        ClubCreatePostInputBoundary interactor = new ClubCreatePostInteractor(userRepository, successPresenter);
+        interactor.switchToCreatePostView();
+    }
+
+    @Test
+    public void successTestSwitchToHomeView() {
+        // Initialise the club factory.
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        // Create the club
+        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Initialise the DAO. In our case, we will the in memory DAO for tests.
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+
+
+        // Save the club to the in memory DAO/Database
+        userRepository.saveClub(testClub);
+
+        // Create the successPresenter that tests whether the test case is as we expect.
+        ClubCreatePostOutputBoundary successPresenter = new ClubCreatePostOutputBoundary() {
+            @Override
+            public void prepareSuccessView(ClubCreatePostOutputData outputData) {
+                fail("Shouldn't run this");
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail(errorMessage);
+            }
+
+            @Override
+            public void switchToCreatePostView() {
+                fail("Shouldn't run this");
+            }
+
+            @Override
+            public void switchToClubLoggedInView() {
+                // This is expected since we are just switching views. This will always be true.
+            }
+        };
+
+        // Execute the use case that need to be tested.
+        ClubCreatePostInputBoundary interactor = new ClubCreatePostInteractor(userRepository, successPresenter);
+        interactor.switchToClubLoggedInView();
     }
 
     @Test

--- a/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
+++ b/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
@@ -48,6 +48,10 @@ public class ClubGetMembersInteractorTest {
         ClubGetMembersOutputBoundary successPresenter = new ClubGetMembersOutputBoundary() {
             @Override
             public void prepareSuccessView(ClubGetMembersOutputData outputData) {
+                assertEquals(false, outputData.isUseCaseFailed());
+                // Check email
+                Club dbClub = userRepository.getClub(inputData.getClubEmail());
+                assertEquals(dbClub.getEmail(), outputData.getEmail());
                 // Get the members Names and emails from the verification list.
                 ArrayList<String> membersNames = new ArrayList<>();
                 ArrayList<String> membersEmails = new ArrayList<>();

--- a/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
+++ b/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * Test for the club login use case. Impossible to get 100% coverage due to switch method
+ * Test for the club login use case.
  */
 public class ClubLoginInteractorTest {
     static String clubName = "Test Club Name";
@@ -54,6 +54,9 @@ public class ClubLoginInteractorTest {
                 int sizePosts = dbClub.getClubPosts().size();
                 assertEquals(0, sizeMembers);
                 assertEquals(0, sizePosts);
+
+                // Check description
+                assertEquals(dbClub.getClubDescription(), clubLoginOutputData.getDescription());
             }
 
             @Override
@@ -69,6 +72,47 @@ public class ClubLoginInteractorTest {
         // Execute the use case that need to be tested.
         ClubLoginInputBoundary interactor = new ClubLoginInteractor(userRepository, successPresenter);
         interactor.execute(inputData);
+    }
+
+    @Test
+    public void successTestSwitchToClubSignupView() {
+        // Initialise the club factory
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        // Initialise the DAO. In our case, we will the in memory DAO for tests.
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+
+        // Create a club (sign up)
+        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
+
+        // Save Club to the DB (execute sign up use case)
+        userRepository.saveClub(testClub);
+
+        // Create the input data for club login use case.
+        ClubLoginInputData inputData = new ClubLoginInputData(testClub.getEmail(), testClub.getPassword());
+
+
+        // Create the successPresenter that tests whether the test case is as we expect.
+        ClubLoginOutputBoundary successPresenter = new ClubLoginOutputBoundary() {
+            @Override
+            public void prepareSuccessView(ClubLoginOutputData clubLoginOutputData) {
+                fail("Shouldn't run this case.");
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail(errorMessage);
+            }
+
+            @Override
+            public void switchToClubSignupView() {
+                // Normal to be empty since there is no way to test switch. This will always be true.
+            }
+        };
+        // Execute the use case that need to be tested.
+        ClubLoginInputBoundary interactor = new ClubLoginInteractor(userRepository, successPresenter);
+        interactor.switchToClubSignupView();
+
     }
 
     @Test

--- a/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
+++ b/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
@@ -42,11 +42,11 @@ public class StudentLoginInteractorTest {
                 assertEquals(false, studentLoginOutputData.useCaseFailed());
 
                 // Verify that the test student has same values
-                assertEquals(testStudent.getEmail(), studentLoginOutputData.getEmail());
-                assertEquals(testStudent.getUsername(), studentLoginOutputData.getUsername());
+                Student dbStudent = userRepository.getStudent(studentLoginOutputData.getEmail());
+                assertEquals(dbStudent.getEmail(), studentLoginOutputData.getEmail());
+                assertEquals(dbStudent.getUsername(), studentLoginOutputData.getUsername());
 
                 // Verify that the database has the same info
-                Student dbStudent = userRepository.getStudent(studentLoginOutputData.getEmail());
                 assertEquals(dbStudent.getEmail(), studentLoginOutputData.getEmail());
                 assertEquals(dbStudent.getUsername(), studentLoginOutputData.getUsername());
 
@@ -69,6 +69,43 @@ public class StudentLoginInteractorTest {
         // Execute the use case that need to be tested.
         StudentLoginInputBoundary interactor = new StudentLoginInteractor(userRepository, successPresenter);
         interactor.execute(inputData);
+    }
+
+    @Test
+    public void successTestSwitchToStudentSignupView() {
+        // Initialise Student Factory
+        StudentFactory studentFactory = new StudentUserFactory();
+
+        // Initialise the DAO. In our case, we will the in memory DAO for tests.
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+
+        // Create the student (register)
+        Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
+
+        // Save student to DB (register use case execution)
+        userRepository.saveStudent(testStudent);
+
+        // Create the successPresenter that tests whether the test case is as we expect.
+        StudentLoginOutputBoundary successPresenter = new StudentLoginOutputBoundary() {
+            @Override
+            public void prepareSuccessView(StudentLoginOutputData studentLoginOutputData) {
+                fail("Shouldn't run this.");
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail(errorMessage);
+            }
+
+            @Override
+            public void switchToStudentSignupView() {
+                // ignore since this will not be called during tests
+            }
+        };
+
+        // Execute the use case that need to be tested.
+        StudentLoginInputBoundary interactor = new StudentLoginInteractor(userRepository, successPresenter);
+        interactor.switchToStudentSignupView();
     }
 
     @Test


### PR DESCRIPTION
As the title suggests, I had debugged and fixed create posts. Turns out I missed a test case, which caused me to miss the fact that the posts were being saved twice. I fixed it and now it works as intended.

Moreover, after asking on piazza, turns out we have to write tests for the switch to view methods. Thus I added those to obtain 100% coverage.

Finally, I added more tests to Club and Student entity. It turns out that, for example, when writing tests for Student, we also had to write all tests for clubs in the same file to count as 100% coverage... Weird! My question is, should I keep the code as is, or should I make one single tests file for both Club and Student entities?

Anyway, the code works 100% as intended. My version of the branch might be a little behind, so be aware of merge issues.

UPDATE: The issue I encountered with tests was due to coupling problems. This was fixed in a more recent PR.