### PR TITLE
Refactor entity

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -6,7 +6,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.ClubUserFactory;
 import entity.user.StudentUserFactory;
 import interface_adapter.ViewManagerModel;
@@ -127,7 +127,7 @@ public class AppBuilder {
     private final ViewManager viewManager = new ViewManager(cardLayout, cardPanel, viewManagerModel);
 
     // thought question: is the hard dependency below a problem?
-    private final InMemoryUserDataAccessObject inMemoryUserDataAccessObject = new InMemoryUserDataAccessObject();
+    private final InMemoryUserDataStudentAccessObject inMemoryUserDataAccessObject = new InMemoryUserDataStudentAccessObject();
 
     private ClubSignupViewModel clubSignupViewModel;
     private ClubSignupView clubSignupView;
@@ -306,7 +306,9 @@ public class AppBuilder {
 
     public AppBuilder addShowPostsUseCase() {
         final StudentShowPostsOutputBoundary studentShowPostsOutputBoundary = new StudentShowPostsPresenter(studentHomeViewModel, viewManagerModel);
-        final StudentShowPostsInputBoundary showPostsInteractor = new StudentShowPostsInteractor(inMemoryUserDataAccessObject,
+
+        final StudentShowPostsInputBoundary showPostsInteractor = new StudentShowPostsInteractor(
+                inMemoryUserDataAccessObject, inMemoryUserDataAccessObject,
                 studentShowPostsOutputBoundary);
 
         final StudentShowPostsController studentShowPostsController = new StudentShowPostsController(showPostsInteractor);

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -6,7 +6,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.ClubUserFactory;
 import entity.user.StudentUserFactory;
 import interface_adapter.ViewManagerModel;
@@ -127,7 +127,7 @@ public class AppBuilder {
     private final ViewManager viewManager = new ViewManager(cardLayout, cardPanel, viewManagerModel);
 
     // thought question: is the hard dependency below a problem?
-    private final InMemoryUserDataStudentAccessObject inMemoryUserDataAccessObject = new InMemoryUserDataStudentAccessObject();
+    private final InMemoryUserDataAccessObject inMemoryUserDataAccessObject = new InMemoryUserDataAccessObject();
 
     private ClubSignupViewModel clubSignupViewModel;
     private ClubSignupView clubSignupView;

--- a/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
@@ -2,6 +2,7 @@ package data_access;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -134,6 +135,12 @@ public class ClubFirestoreUserDataAccessObject implements ClubCreatePostUserData
             // Handle exceptions appropriately
             ex.printStackTrace();
         }
+    }
+
+    @Override
+    public ArrayList<Post> getPosts(Club club) {
+        // temp
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/ClubFirestoreUserDataAccessObject.java
@@ -32,6 +32,7 @@ import use_case.login.club_login.ClubLoginDataAccessInterface;
 import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
 import use_case.student_homepage.dislike.StudentDislikeClubDataAccessInterface;
 import use_case.student_homepage.like.StudentLikeClubDataAccessInterface;
+import use_case.student_homepage.show_posts.StudentShowPostsClubAccessInterface;
 import use_case.student_join_club.ClubStudentJoinClubDataAccessInterface;
 import use_case.student_leave_club.ClubStudentLeaveClubDataAccessInterface;
 
@@ -44,7 +45,8 @@ public class ClubFirestoreUserDataAccessObject implements ClubCreatePostUserData
         ClubGetMembersUserDataAccessInterface, ClubRemoveMemberClubDataAccessInterface, ClubLoginDataAccessInterface,
         ClubSignupUserDataAccessInterface, ClubStudentJoinClubDataAccessInterface,
         ClubStudentLeaveClubDataAccessInterface, ClubExploreClubsDataAccessInterface, ClubGetPostsDataAccessInterface,
-        ClubUpdateDescDataAccessInterface, StudentDislikeClubDataAccessInterface, StudentLikeClubDataAccessInterface {
+        ClubUpdateDescDataAccessInterface, StudentDislikeClubDataAccessInterface,
+        StudentLikeClubDataAccessInterface, StudentShowPostsClubAccessInterface {
     private final Firestore db;
     private final String clubs = "clubs";
     private final String usernames = "username";

--- a/src/main/java/data_access/InMemoryUserDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataAccessObject.java
@@ -74,6 +74,21 @@ public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInt
 //    }
 
     @Override
+    public ArrayList<Club> getStudentJoinedClubs(Student student) {
+        final DataStore<Club> clubs = clubMap.get("clubs");
+        final ArrayList<Club> joinedClubs = new ArrayList<>();
+        int index = 0;
+        while (index < clubs.size()) {
+            final Club currClub = clubs.getByIndex(index);
+            if (currClub.getClubMembersEmails().contains(student.getEmail())) {
+                joinedClubs.add(currClub);
+            }
+            index++;
+        }
+        return joinedClubs;
+    }
+
+    @Override
     public ArrayList<Post> getPosts(Club club) {
         final DataStore<ArrayList<Post>> posts = clubMap.get("posts");
         final DataStore<Club> clubs = clubMap.get("clubs");

--- a/src/main/java/data_access/InMemoryUserDataAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataAccessObject.java
@@ -1,5 +1,7 @@
 package data_access;
 
+import java.util.ArrayList;
+
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
 import entity.post.Post;
@@ -11,6 +13,8 @@ import use_case.club_get_posts.ClubGetPostsDataAccessInterface;
 import use_case.club_remove_member.ClubRemoveMemberClubDataAccessInterface;
 import use_case.club_remove_member.ClubRemoveMemberStudentDataAccessInterface;
 import use_case.club_update_desc.ClubUpdateDescDataAccessInterface;
+import use_case.explore_clubs.ClubExploreClubsDataAccessInterface;
+import use_case.explore_clubs.StudentExploreClubsDataAccessInterface;
 import use_case.login.club_login.ClubLoginDataAccessInterface;
 import use_case.login.student_login.StudentLoginDataAccessInterface;
 import use_case.signup.club_signup.ClubSignupUserDataAccessInterface;
@@ -22,22 +26,16 @@ import use_case.student_homepage.like.StudentLikeStudentDataAccessInterface;
 import use_case.student_homepage.show_clubs.StudentShowClubsAccessInterface;
 import use_case.student_homepage.show_posts.StudentShowPostsClubAccessInterface;
 import use_case.student_homepage.show_posts.StudentShowPostsStudentAccessInterface;
-import use_case.explore_clubs.StudentExploreClubsDataAccessInterface;
-import use_case.explore_clubs.ClubExploreClubsDataAccessInterface;
-import use_case.student_join_club.StudentJoinClubDataAccessInterface;
 import use_case.student_join_club.ClubStudentJoinClubDataAccessInterface;
-import use_case.student_leave_club.StudentLeaveClubDataAccessInterface;
+import use_case.student_join_club.StudentJoinClubDataAccessInterface;
 import use_case.student_leave_club.ClubStudentLeaveClubDataAccessInterface;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import use_case.student_leave_club.StudentLeaveClubDataAccessInterface;
 
 /**
  * In-memory implementation of the DAO for storing user data. This implementation does
  * NOT persist data between runs of the program.
  */
-public class InMemoryUserDataStudentAccessObject implements ClubSignupUserDataAccessInterface,
+public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInterface,
         StudentSignupUserDataAccessInterface,
         ClubLoginDataAccessInterface, StudentLoginDataAccessInterface, ClubCreatePostUserDataAccessInterface,
         ClubGetPostsDataAccessInterface, ClubRemoveMemberClubDataAccessInterface,
@@ -55,19 +53,6 @@ public class InMemoryUserDataStudentAccessObject implements ClubSignupUserDataAc
     private final ArrayList<Student> studentArrayList = new ArrayList<>();
     private final ArrayList<Club> clubArrayList = new ArrayList<>();
     private final ArrayList<ArrayList<Post>> postArrayList = new ArrayList<>();
-
-//    public InMemoryUserDataAccessObject() {
-//        final Club club = new Club("test", "@.", "123123123", new DataStoreArrays<>(),
-//                new DataStoreArrays<>());
-//        final Student student = new Student("student", "student@.", "123123123", new DataStoreArrays<>());
-//        studentArrayList.add(student);
-//        student.joinClub(club);
-//        System.out.println(studentArrayList.size());
-//        club.addClubMember(student);
-//        clubArrayList.add(club);
-//
-//        // TODO REMOVE THIS AFTER TESTING REMOVE MEMBERS
-//    }
 
     @Override
     public ArrayList<Club> getStudentJoinedClubs(Student student) {

--- a/src/main/java/data_access/InMemoryUserDataStudentAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataStudentAccessObject.java
@@ -202,7 +202,8 @@ public class InMemoryUserDataStudentAccessObject implements ClubSignupUserDataAc
 
     @Override
     public void updateStudentClubsJoined(Student student) {
-        saveStudent(student);
+        studentArrayList.remove(student);
+        studentArrayList.add(student);
     }
 
     @Override

--- a/src/main/java/data_access/InMemoryUserDataStudentAccessObject.java
+++ b/src/main/java/data_access/InMemoryUserDataStudentAccessObject.java
@@ -20,7 +20,8 @@ import use_case.student_homepage.dislike.StudentDislikeStudentDataAccessInterfac
 import use_case.student_homepage.like.StudentLikeClubDataAccessInterface;
 import use_case.student_homepage.like.StudentLikeStudentDataAccessInterface;
 import use_case.student_homepage.show_clubs.StudentShowClubsAccessInterface;
-import use_case.student_homepage.show_posts.StudentShowPostsAccessInterface;
+import use_case.student_homepage.show_posts.StudentShowPostsClubAccessInterface;
+import use_case.student_homepage.show_posts.StudentShowPostsStudentAccessInterface;
 import use_case.explore_clubs.StudentExploreClubsDataAccessInterface;
 import use_case.explore_clubs.ClubExploreClubsDataAccessInterface;
 import use_case.student_join_club.StudentJoinClubDataAccessInterface;
@@ -28,7 +29,6 @@ import use_case.student_join_club.ClubStudentJoinClubDataAccessInterface;
 import use_case.student_leave_club.StudentLeaveClubDataAccessInterface;
 import use_case.student_leave_club.ClubStudentLeaveClubDataAccessInterface;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,23 +37,25 @@ import java.util.Map;
  * In-memory implementation of the DAO for storing user data. This implementation does
  * NOT persist data between runs of the program.
  */
-public class InMemoryUserDataAccessObject implements ClubSignupUserDataAccessInterface,
+public class InMemoryUserDataStudentAccessObject implements ClubSignupUserDataAccessInterface,
         StudentSignupUserDataAccessInterface,
         ClubLoginDataAccessInterface, StudentLoginDataAccessInterface, ClubCreatePostUserDataAccessInterface,
         ClubGetPostsDataAccessInterface, ClubRemoveMemberClubDataAccessInterface,
         ClubRemoveMemberStudentDataAccessInterface,
         ClubUpdateDescDataAccessInterface,
-        ClubGetMembersUserDataAccessInterface, StudentShowPostsAccessInterface, StudentLikeClubDataAccessInterface,
+        ClubGetMembersUserDataAccessInterface, StudentShowPostsStudentAccessInterface,
+        StudentLikeClubDataAccessInterface,
         StudentLikeStudentDataAccessInterface, StudentDislikeClubDataAccessInterface,
         StudentDislikeStudentDataAccessInterface, StudentShowClubsAccessInterface,
         StudentExploreClubsDataAccessInterface, ClubExploreClubsDataAccessInterface,
         StudentJoinClubDataAccessInterface, ClubStudentJoinClubDataAccessInterface,
-        StudentLeaveClubDataAccessInterface, ClubStudentLeaveClubDataAccessInterface {
+        StudentLeaveClubDataAccessInterface, ClubStudentLeaveClubDataAccessInterface,
+        StudentShowPostsClubAccessInterface {
 
     private final DataStoreArrays<Student> studentArrayList = new DataStoreArrays<>();
     private final Map<String, DataStore> clubMap = new HashMap<>();
 
-    public InMemoryUserDataAccessObject() {
+    public InMemoryUserDataStudentAccessObject() {
         final DataStoreArrays<Club> clubArrayList = new DataStoreArrays<>();
         final DataStoreArrays<ArrayList<Post>> postArrayList = new DataStoreArrays<>();
         clubMap.put("clubs", clubArrayList);

--- a/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
@@ -35,7 +35,7 @@ import use_case.student_search_club.StudentSearchClubAccessInterface;
  * This implementation uses Firebase and only persists data regarding the
  * Student entity
  */
-public class StudentFirestoreUserDataStudentAccessObject implements StudentLoginDataAccessInterface,
+public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAccessInterface,
         StudentSignupUserDataAccessInterface, StudentJoinClubDataAccessInterface,
         StudentLeaveClubDataAccessInterface, StudentSearchClubAccessInterface,
         ClubRemoveMemberStudentDataAccessInterface, StudentExploreClubsDataAccessInterface,
@@ -45,7 +45,7 @@ public class StudentFirestoreUserDataStudentAccessObject implements StudentLogin
     private final String students = "students";
     private final String usernames = "username";
 
-    public StudentFirestoreUserDataStudentAccessObject() throws IOException {
+    public StudentFirestoreUserDataAccessObject() throws IOException {
         // TODO fix this to be environment variable
         final FileInputStream serviceAccount =
                 new FileInputStream("/ServiceAccountKey.json");

--- a/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataAccessObject.java
@@ -2,6 +2,7 @@ package data_access;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 
 import com.google.api.core.ApiFuture;
@@ -14,6 +15,7 @@ import com.google.cloud.firestore.WriteResult;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.cloud.FirestoreClient;
+import entity.user.Club;
 import entity.user.Student;
 import use_case.club_remove_member.ClubRemoveMemberStudentDataAccessInterface;
 import use_case.explore_clubs.StudentExploreClubsDataAccessInterface;
@@ -72,6 +74,18 @@ public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAcc
             ex.printStackTrace();
         }
         return returnValue;
+    }
+
+    /**
+     * Gets the joined clubs for the given student.
+     *
+     * @param student the student
+     * @return an array lists of clubs
+     */
+    @Override
+    public ArrayList<Club> getStudentJoinedClubs(Student student) {
+        // temp. See in memory for implementation
+        return null;
     }
 
     @Override

--- a/src/main/java/data_access/StudentFirestoreUserDataStudentAccessObject.java
+++ b/src/main/java/data_access/StudentFirestoreUserDataStudentAccessObject.java
@@ -25,7 +25,7 @@ import use_case.student_homepage.StudentHomeAccessInterface;
 import use_case.student_homepage.dislike.StudentDislikeStudentDataAccessInterface;
 import use_case.student_homepage.like.StudentLikeStudentDataAccessInterface;
 import use_case.student_homepage.show_clubs.StudentShowClubsAccessInterface;
-import use_case.student_homepage.show_posts.StudentShowPostsAccessInterface;
+import use_case.student_homepage.show_posts.StudentShowPostsStudentAccessInterface;
 import use_case.student_join_club.StudentJoinClubDataAccessInterface;
 import use_case.student_leave_club.StudentLeaveClubDataAccessInterface;
 import use_case.student_search_club.StudentSearchClubAccessInterface;
@@ -35,17 +35,17 @@ import use_case.student_search_club.StudentSearchClubAccessInterface;
  * This implementation uses Firebase and only persists data regarding the
  * Student entity
  */
-public class StudentFirestoreUserDataAccessObject implements StudentLoginDataAccessInterface,
+public class StudentFirestoreUserDataStudentAccessObject implements StudentLoginDataAccessInterface,
         StudentSignupUserDataAccessInterface, StudentJoinClubDataAccessInterface,
         StudentLeaveClubDataAccessInterface, StudentSearchClubAccessInterface,
         ClubRemoveMemberStudentDataAccessInterface, StudentExploreClubsDataAccessInterface,
         StudentDislikeStudentDataAccessInterface, StudentLikeStudentDataAccessInterface,
-        StudentShowClubsAccessInterface, StudentShowPostsAccessInterface, StudentHomeAccessInterface {
+        StudentShowClubsAccessInterface, StudentShowPostsStudentAccessInterface, StudentHomeAccessInterface {
     private final Firestore db;
     private final String students = "students";
     private final String usernames = "username";
 
-    public StudentFirestoreUserDataAccessObject() throws IOException {
+    public StudentFirestoreUserDataStudentAccessObject() throws IOException {
         // TODO fix this to be environment variable
         final FileInputStream serviceAccount =
                 new FileInputStream("/ServiceAccountKey.json");

--- a/src/main/java/entity/post/Announcement.java
+++ b/src/main/java/entity/post/Announcement.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
 import entity.user.User;
 
 /**

--- a/src/main/java/entity/post/Announcement.java
+++ b/src/main/java/entity/post/Announcement.java
@@ -75,7 +75,7 @@ public class Announcement implements Post {
 
     @Override
     public DataStore<String> getLikes() {
-        return this.userDisliked;
+        return this.userLiked;
     }
 
     @Override

--- a/src/main/java/entity/post/Announcement.java
+++ b/src/main/java/entity/post/Announcement.java
@@ -21,14 +21,14 @@ public class Announcement implements Post {
     private LocalDate dateOfPosting;
 
     // Like/Dislike information of post
-    private DataStore<User> likes;
-    private DataStore<User> dislikes;
+    private DataStore<String> userLiked;
+    private DataStore<String> userDisliked;
 
-    public Announcement(String title, String content) {
+    public Announcement(String title, String content, DataStore<String> userLiked, DataStore<String> userDisliked) {
         this.title = title;
         this.content = content;
-        this.likes = new DataStoreArrays<>();
-        this.dislikes = new DataStoreArrays<>();
+        this.userLiked = userLiked;
+        this.userDisliked = userDisliked;
         this.timeOfPosting = LocalTime.now();
         this.dateOfPosting = LocalDate.now();
     }
@@ -62,7 +62,7 @@ public class Announcement implements Post {
      * @return int number of likes.
      */
     public int numberOfLikes() {
-        return likes.size();
+        return userLiked.size();
     }
 
     /**
@@ -70,17 +70,17 @@ public class Announcement implements Post {
      * @return int the number of dislikes
      */
     public int numberOfDislikes() {
-        return dislikes.size();
+        return userDisliked.size();
     }
 
     @Override
-    public DataStore<User> getLikes() {
-        return this.likes;
+    public DataStore<String> getLikes() {
+        return this.userDisliked;
     }
 
     @Override
-    public DataStore<User> getDislikes() {
-        return this.dislikes;
+    public DataStore<String> getDislikes() {
+        return this.userDisliked;
     }
 
     /**
@@ -88,7 +88,7 @@ public class Announcement implements Post {
      * @param user user that likes the post.
      */
     public void addLike(User user) {
-        likes.add(user);
+        userLiked.add(user.getEmail());
     }
 
     /**
@@ -96,7 +96,7 @@ public class Announcement implements Post {
      * @param user that unlikes the post
      */
     public void removeLike(User user) {
-        likes.remove(user);
+        userLiked.remove(user.getEmail());
     }
 
     /**
@@ -104,7 +104,7 @@ public class Announcement implements Post {
      * @param user that dislikes the post
      */
     public void addDislike(User user) {
-        dislikes.add(user);
+        userDisliked.add(user.getEmail());
     }
 
     /**
@@ -112,7 +112,7 @@ public class Announcement implements Post {
      * @param user that wants to remove dislike
      */
     public void removeDislike(User user) {
-        dislikes.remove(user);
+        userDisliked.remove(user.getEmail());
     }
 
 }

--- a/src/main/java/entity/post/AnnouncementFactory.java
+++ b/src/main/java/entity/post/AnnouncementFactory.java
@@ -13,7 +13,7 @@ public class AnnouncementFactory implements PostFactory {
      * @param content contents of the post.
      * @return the new post
      */
-    public Post create(String title, String content) {
+    public Announcement create(String title, String content) {
         return new Announcement(title, content, new DataStoreArrays<>(), new DataStoreArrays<>());
     }
 }

--- a/src/main/java/entity/post/AnnouncementFactory.java
+++ b/src/main/java/entity/post/AnnouncementFactory.java
@@ -1,5 +1,7 @@
 package entity.post;
 
+import entity.data_structure.DataStoreArrays;
+
 /**
  * Factory for creating new Announcement posts.
  */
@@ -12,6 +14,6 @@ public class AnnouncementFactory implements PostFactory {
      * @return the new post
      */
     public Post create(String title, String content) {
-        return new Announcement(title, content);
+        return new Announcement(title, content, new DataStoreArrays<>(), new DataStoreArrays<>());
     }
 }

--- a/src/main/java/entity/post/Post.java
+++ b/src/main/java/entity/post/Post.java
@@ -62,13 +62,13 @@ public interface Post {
      * Return the datastore object of all the likes of the post.
      * @return the datastore object of all users who liked the post.
      */
-    DataStore<User> getLikes();
+    DataStore<String> getLikes();
 
     /**
      * Return the datastore object of all the dislikes of the post.
      * @return the datastore object of all users who disliked the post.
      */
-    DataStore<User> getDislikes();
+    DataStore<String> getDislikes();
 
     /**
      * Returns the date of publication of the post.

--- a/src/main/java/entity/user/Club.java
+++ b/src/main/java/entity/user/Club.java
@@ -13,19 +13,25 @@ public class Club implements User {
     private final String password;
     private String clubDescription = "";
     // Club's members and Posts information
-    private final DataStore<Student> clubMembers;
-    private final DataStore<Post> clubPosts;
+    private final DataStore<String> clubMembersEmails;
+    private final DataStore<String> clubMembersNames;
 
-    public Club(String username, String email, String password, DataStore<Student> clubMembers,
-                DataStore<Post> clubPosts) {
+    private final DataStore<String> clubPostsTitle;
+    private final DataStore<String> clubPostsDescription;
+
+    public Club(String username, String email, String password, DataStore<String> clubMembersEmails,
+                DataStore<String> clubMembersNames, DataStore<String> clubPostsTitle,
+                DataStore<String> clubPostsDescription) {
         // Initialize club personal information
         this.username = username;
         this.email = email;
         this.password = password;
 
         // Initialize club members and posts information
-        this.clubMembers = clubMembers;
-        this.clubPosts = clubPosts;
+        this.clubMembersEmails = clubMembersEmails;
+        this.clubMembersNames = clubMembersNames;
+        this.clubPostsTitle = clubPostsTitle;
+        this.clubPostsDescription = clubPostsDescription;
     }
 
     public String getUsername() {
@@ -44,12 +50,20 @@ public class Club implements User {
         return clubDescription;
     }
 
-    public DataStore<Student> getClubMembers() {
-        return clubMembers;
+    public DataStore<String> getClubMembersEmails() {
+        return clubMembersEmails;
     }
 
-    public DataStore<Post> getClubPosts() {
-        return clubPosts;
+    public DataStore<String> getClubMembersNames() {
+        return clubMembersNames;
+    }
+
+    public DataStore<String> getClubPostsTitle() {
+        return clubPostsTitle;
+    }
+
+    public DataStore<String> getClubPostsDescription() {
+        return clubPostsDescription;
     }
 
     /**
@@ -57,7 +71,8 @@ public class Club implements User {
      * @param user particular user joining the club.
      */
     public void addClubMember(Student user) {
-        clubMembers.add(user);
+        clubMembersEmails.add(user.getEmail());
+        clubMembersNames.add(user.getUsername());
     }
 
     /**
@@ -65,7 +80,8 @@ public class Club implements User {
      * @param post particular post to add.
      */
     public void addClubPost(Post post) {
-        clubPosts.add(post);
+        clubPostsTitle.add(post.getTitle());
+        clubPostsDescription.add(post.getContent());
     }
 
     /**
@@ -73,7 +89,8 @@ public class Club implements User {
      * @param user particular user leaving the club.
      */
     public void removeClubMember(Student user) {
-        clubMembers.remove(user);
+        clubPostsDescription.remove(user.getUsername());
+        clubMembersEmails.remove(user.getEmail());
     }
 
     /**
@@ -81,7 +98,8 @@ public class Club implements User {
      * @param post particular post to be removed
      */
     public void removeClubPost(Post post) {
-        clubPosts.remove(post);
+        clubPostsDescription.remove(post.getTitle());
+        clubMembersNames.remove(post.getContent());
     }
 
     public void setClubDescription(String newDescription) {

--- a/src/main/java/entity/user/Club.java
+++ b/src/main/java/entity/user/Club.java
@@ -89,7 +89,7 @@ public class Club implements User {
      * @param user particular user leaving the club.
      */
     public void removeClubMember(Student user) {
-        clubPostsDescription.remove(user.getUsername());
+        clubMembersNames.remove(user.getUsername());
         clubMembersEmails.remove(user.getEmail());
     }
 

--- a/src/main/java/entity/user/ClubFactory.java
+++ b/src/main/java/entity/user/ClubFactory.java
@@ -1,7 +1,6 @@
 package entity.user;
 
 import entity.data_structure.DataStore;
-import entity.post.Post;
 
 /**
  * Factory for creating Clubs.
@@ -15,10 +14,13 @@ public interface ClubFactory extends UserFactory {
      * @param username the username of the new club
      * @param email the email of the new club
      * @param password the password of the new club
-     * @param clubMembers the members of the new club
-     * @param clubPosts the posts of the new club
+     * @param clubMembersEmails the members email
+     * @param clubMembersNames the members name
+     * @param clubPostsTitle the posts title
+     * @param clubPostsDescription the posts description
      * @return the new club user
      */
-    Club create(String username, String email, String password, DataStore<Student> clubMembers,
-                DataStore<Post> clubPosts);
+    Club create(String username, String email, String password, DataStore<String> clubMembersEmails,
+                DataStore<String> clubMembersNames, DataStore<String> clubPostsTitle,
+                DataStore<String> clubPostsDescription);
 }

--- a/src/main/java/entity/user/ClubUserFactory.java
+++ b/src/main/java/entity/user/ClubUserFactory.java
@@ -2,7 +2,6 @@ package entity.user;
 
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.post.Post;
 
 /**
  * Factory for creating Club user objets.
@@ -10,22 +9,18 @@ import entity.post.Post;
 public class ClubUserFactory implements ClubFactory {
     @Override
     public Club create(String name, String email, String password) {
-        final DataStoreArrays<Student> clubMembers = new DataStoreArrays<>();
-        final DataStoreArrays<Post> clubPosts = new DataStoreArrays<>();
-        return new Club(name, email, password, clubMembers, clubPosts);
+        final DataStoreArrays<String> membersEmails = new DataStoreArrays<>();
+        final DataStoreArrays<String> membersNames = new DataStoreArrays<>();
+        final DataStore<String> clubPostsTitle = new DataStoreArrays<>();
+        final DataStore<String> clubPostsDescription = new DataStoreArrays<>();
+        return new Club(name, email, password, membersEmails, membersNames, clubPostsTitle, clubPostsDescription);
     }
 
-    /**
-     * Create a new Club user.
-     * @param username the username of the new club
-     * @param email the email of the new club
-     * @param password the password of the new club
-     * @param clubMembers the members of the new club
-     * @param clubPosts the posts of the new club
-     * @return the new club user
-     */
-    public Club create(String username, String email, String password, DataStore<Student> clubMembers,
-                DataStore<Post> clubPosts) {
-        return new Club(username, email, password, clubMembers, clubPosts);
+    @Override
+    public Club create(String username, String email, String password, DataStore<String> clubMembersEmails,
+                       DataStore<String> clubMembersNames, DataStore<String> clubPostsTitle,
+                       DataStore<String> clubPostsDescription) {
+        return new Club(username, email, password, clubMembersEmails, clubMembersNames, clubPostsTitle,
+                clubPostsDescription);
     }
 }

--- a/src/main/java/entity/user/Student.java
+++ b/src/main/java/entity/user/Student.java
@@ -7,21 +7,24 @@ import entity.data_structure.DataStore;
  */
 public class Student implements User {
     // Student's personal information
-    private String username;
-    private String email;
-    private String password;
+    private final String username;
+    private final String email;
+    private final String password;
 
     // Student club information
-    private DataStore<Club> joinedClubs;
+    private final DataStore<String> joinedClubsNames;
+    private final DataStore<String> joinedClubsEmails;
 
-    public Student(String username, String email, String password, DataStore<Club> joinedClubs) {
+    public Student(String username, String email, String password, DataStore<String> joinedClubsEmails,
+                   DataStore<String> joinedClubsNames) {
         // Initialise student's personal information
         this.username = username;
         this.email = email;
         this.password = password;
 
         // Initialise student's club information
-        this.joinedClubs = joinedClubs;
+        this.joinedClubsEmails = joinedClubsEmails;
+        this.joinedClubsNames = joinedClubsNames;
     }
 
     public String getUsername() {
@@ -36,8 +39,12 @@ public class Student implements User {
         return password;
     }
 
-    public DataStore<Club> getJoinedClubs() {
-        return joinedClubs;
+    public DataStore<String> getJoinedClubsNames() {
+        return joinedClubsNames;
+    }
+
+    public DataStore<String> getJoinedClubsEmails() {
+        return joinedClubsEmails;
     }
 
     /**
@@ -45,7 +52,8 @@ public class Student implements User {
      * @param club particular club to be joined.
      */
     public void joinClub(Club club) {
-        joinedClubs.add(club);
+        joinedClubsNames.add(club.getUsername());
+        joinedClubsEmails.add(club.getEmail());
     }
 
     /**
@@ -53,7 +61,8 @@ public class Student implements User {
      * @param club particular club to be left.
      */
     public void leaveClub(Club club) {
-        joinedClubs.remove(club);
+        joinedClubsNames.remove(club.getUsername());
+        joinedClubsEmails.remove(club.getEmail());
     }
 
 }

--- a/src/main/java/entity/user/StudentFactory.java
+++ b/src/main/java/entity/user/StudentFactory.java
@@ -15,8 +15,10 @@ public interface StudentFactory extends UserFactory {
      * @param name the name of the new student
      * @param email the email of the new student
      * @param password the password of the new student
-     * @param joinedClubs the clubs the student has joined
+     * @param joinedClubsEmails the emails of the clubs joined
+     * @param joinedClubsNames the names of the clubs joined
      * @return the new student user
      */
-    Student create(String name, String email, String password, DataStore<Club> joinedClubs);
+    Student create(String name, String email, String password, DataStore<String> joinedClubsEmails,
+                   DataStore<String> joinedClubsNames);
 }

--- a/src/main/java/entity/user/StudentUserFactory.java
+++ b/src/main/java/entity/user/StudentUserFactory.java
@@ -11,20 +11,15 @@ public class StudentUserFactory implements StudentFactory {
     @Override
     public Student create(String name, String email, String password) {
         // new users that are part of no clubs.
-        final DataStoreArrays<Club> joinedClubs = new DataStoreArrays<>();
-        return new Student(name, email, password, joinedClubs);
+        final DataStoreArrays<String> joinedClubsEmails = new DataStoreArrays<>();
+        final DataStoreArrays<String> joinedClubsNames = new DataStoreArrays<>();
+        return new Student(name, email, password, joinedClubsEmails, joinedClubsNames);
     }
 
-    /**
-     * Create a new student user.
-     * @param name the name of the new student
-     * @param email the email of the new student
-     * @param password the password of the new student
-     * @param joinedClubs the clubs the student has joined
-     * @return the new student user
-     */
-    public Student create(String name, String email, String password, DataStore<Club> joinedClubs) {
-        return new Student(name, email, password, joinedClubs);
+    @Override
+    public Student create(String name, String email, String password, DataStore<String> joinedClubsEmails,
+                          DataStore<String> joinedClubsNames) {
+        return new Student(name, email, password, joinedClubsEmails, joinedClubsNames);
     }
 
 }

--- a/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
@@ -1,6 +1,7 @@
 package use_case.club_create_post;
 
 import entity.post.Announcement;
+import entity.post.AnnouncementFactory;
 import entity.user.Club;
 
 /**
@@ -40,7 +41,8 @@ public class ClubCreatePostInteractor implements ClubCreatePostInputBoundary {
                     + maxTitleLength + " characters.");
         }
         else {
-            final Announcement post = new Announcement(title, content);
+            final AnnouncementFactory announcementFactory = new AnnouncementFactory();
+            final Announcement post = announcementFactory.create(title, content);
             final ClubCreatePostOutputData outputData = new ClubCreatePostOutputData(
                     post.getTitle(), post.getContent(), post.timeOfPosting(), post.dateOfPosting(), false);
             // Get club by email, since the user exists and logged in, we know the email exists for save

--- a/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostInteractor.java
@@ -48,6 +48,9 @@ public class ClubCreatePostInteractor implements ClubCreatePostInputBoundary {
             // Get club by email, since the user exists and logged in, we know the email exists for save
             final Club club = createPostDataAccessObject.getClub(clubCreatePostInputData.getEmail());
 
+            // Save post to club entity
+            club.addClubPost(post);
+
             // Save post to database
             createPostDataAccessObject.savePost(post, club);
 

--- a/src/main/java/use_case/club_create_post/ClubCreatePostUserDataAccessInterface.java
+++ b/src/main/java/use_case/club_create_post/ClubCreatePostUserDataAccessInterface.java
@@ -9,6 +9,7 @@ import entity.user.Club;
 public interface ClubCreatePostUserDataAccessInterface {
     /**
      * Save post to database. The specific post will be stored with the data of the given club.
+     * PRECONDITION: the club already exists and has been saved before.
      * @param post the post that needs to be saved
      * @param club the club that posted
      */

--- a/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
+++ b/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
@@ -3,9 +3,7 @@ package use_case.club_get_members;
 import java.util.ArrayList;
 
 import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
 import entity.user.Club;
-import entity.user.Student;
 
 /**
  * Interactor for the get members use case.

--- a/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
+++ b/src/main/java/use_case/club_get_members/ClubGetMembersInteractor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
+import entity.user.Club;
 import entity.user.Student;
 
 /**
@@ -30,26 +31,31 @@ public class ClubGetMembersInteractor implements ClubGetMembersInputBoundary {
             getMembersPresenter.prepareFailView(clubEmail + ": Account does not exist.");
         }
         else {
-            final DataStore<Student> members = getMembersDataAccessObject.getClub(clubEmail).getClubMembers();
+            // Get Club info
+            final Club dbClub = getMembersDataAccessObject.getClub(clubEmail);
+            final DataStore<String> membersNames = dbClub.getClubMembersNames();
+            final DataStore<String> membersEmails = dbClub.getClubMembersEmails();
 
             // Create the array lists for the output data.
             final ArrayList<String> membersEmail = new ArrayList<>();
             final ArrayList<String> membersName = new ArrayList<>();
 
+            // Populate the lists
             int index = 0;
-            while (index < members.size()) {
-                final Student student = members.getByIndex(index);
+            while (index < membersEmails.size()) {
+                final String studentEmail = membersEmails.getByIndex(index);
+                final String studentName = membersNames.getByIndex(index);
                 // For a student at this index, assign membersEmail and membersName the values
-                membersEmail.add(student.getEmail());
-                membersName.add(student.getUsername());
+                membersEmail.add(studentEmail);
+                membersName.add(studentName);
 
                 // Increment the index
                 index++;
             }
 
             // Create the output data with the ArrayLists
-            final ClubGetMembersOutputData outputData = new ClubGetMembersOutputData(inputData.getClubEmail(), membersEmail,
-                    membersName, false);
+            final ClubGetMembersOutputData outputData = new ClubGetMembersOutputData(inputData.getClubEmail(),
+                    membersEmail, membersName, false);
 
             // Prepare the success view for the given output data
             getMembersPresenter.prepareSuccessView(outputData);

--- a/src/main/java/use_case/club_get_posts/ClubGetPostsInteractor.java
+++ b/src/main/java/use_case/club_get_posts/ClubGetPostsInteractor.java
@@ -3,8 +3,6 @@ package use_case.club_get_posts;
 import java.util.ArrayList;
 
 import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
-import entity.post.Post;
 import entity.user.Club;
 
 /**

--- a/src/main/java/use_case/club_get_posts/ClubGetPostsInteractor.java
+++ b/src/main/java/use_case/club_get_posts/ClubGetPostsInteractor.java
@@ -33,21 +33,28 @@ public class ClubGetPostsInteractor implements ClubGetPostsInputBoundary {
         else {
             // Gets the current club entity and gets a DataStore of its posts
             final Club currentClub = clubGetPostsDataAccessObject.getClub(clubGetPostsInputData.getClubEmail());
+            final DataStore<String> postsTitles = currentClub.getClubPostsTitle();
+            final DataStore<String> postsDescriptions = currentClub.getClubPostsDescription();
 
             /* Stores the posts titles their contents into two arraylists. Calling both lists at the same index
              gives the information for one post. */
-            final DataStore<Post> posts = currentClub.getClubPosts();
-            final ArrayList<String> postTitles = new ArrayList<>();
-            final ArrayList<String> postBodies = new ArrayList<>();
-            for (Post post: (DataStoreArrays<Post>) posts) {
-                postTitles.add(post.getTitle());
-                postBodies.add(post.getContent());
+            final ArrayList<String> titles = new ArrayList<>();
+            final ArrayList<String> descriptions = new ArrayList<>();
+            int index = 0;
+            while (index < postsTitles.size()) {
+                // Get the post data
+                final String tite = postsTitles.getByIndex(index);
+                final String body = postsDescriptions.getByIndex(index);
+                // Populate the array lists
+                titles.add(tite);
+                descriptions.add(body);
+                index++;
             }
 
             // Creates and Passes the output data to the presenter to display and results in a success message
             final String message = "Success in Getting Club Posts";
             final ClubGetPostsOutputData clubGetPostsOutputData = new ClubGetPostsOutputData(message,
-                    postTitles, postBodies);
+                    titles, descriptions);
             clubGetPostsPresenter.prepareDisplayPosts(clubGetPostsOutputData);
         }
     }

--- a/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
+++ b/src/main/java/use_case/club_remove_member/ClubRemoveMemberInteractor.java
@@ -36,7 +36,7 @@ public class ClubRemoveMemberInteractor implements ClubRemoveMemberInputBoundary
             final Student student = clubRemoveStudentDataAccessObject.getStudent(studentEmail);
 
             // Verify that student is in club
-            if (!club.getClubMembers().contains(student)) {
+            if (!club.getClubMembersEmails().contains(student.getEmail())) {
                 clubRemovePresenter.prepareFailView(studentEmail + ": Account not in club.");
             }
             else {

--- a/src/main/java/use_case/explore_clubs/ExploreClubsInteractor.java
+++ b/src/main/java/use_case/explore_clubs/ExploreClubsInteractor.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import entity.data_structure.DataStore;
+import entity.data_structure.DataStoreArrays;
 import entity.user.Club;
 import entity.user.Student;
 
@@ -37,13 +38,23 @@ public class ExploreClubsInteractor implements ExploreClubsInputBoundary {
         else {
             // gets the joined clubs by retrieving user from database and getting joined clubs.
             final Student student = studentExploreClubsDataAccessInterface.getStudent(email);
-            final DataStore<Club> joinedClubs = student.getJoinedClubs();
+            final DataStore<String> joinedClubsEmails = student.getJoinedClubsEmails();
 
             // gets all the clubs from the database.
             final DataStore<Club> allClubs = clubExploreClubsDataAccessInterface.getAllClubs();
 
             // all values of all clubs minus the joined ones
-            final DataStore<Club> complement = allClubs.complement(joinedClubs);
+            final DataStore<Club> complement = new DataStoreArrays<>();
+            int index = 0;
+            while (index < allClubs.size()) {
+                final Club club = allClubs.getByIndex(index);
+                final String clubEmail = club.getEmail();
+                // Check if the student has joined this club. If it did not, then add to complement
+                if (!joinedClubsEmails.contains(clubEmail)) {
+                    complement.add(club);
+                }
+                index++;
+            }
 
             final ArrayList<Map<String, String>> outputMap = new ArrayList<>();
 
@@ -54,16 +65,18 @@ public class ExploreClubsInteractor implements ExploreClubsInputBoundary {
                 map.put("username", club.getUsername());
                 map.put("email", club.getEmail());
                 map.put("description", club.getClubDescription());
-                map.put("numMembers", club.getClubMembers().size().toString());
+                map.put("numMembers", club.getClubMembersNames().size().toString());
                 outputMap.add(map);
             }
-            final ArrayList<String> joinedClubsEmails = new ArrayList<>();
-            for (Club club : joinedClubs.getAll()) {
-                joinedClubsEmails.add(club.getEmail());
+            final ArrayList<String> joinedEmails = new ArrayList<>();
+            int i = 0;
+            while (i < joinedClubsEmails.size()) {
+                joinedEmails.add(joinedClubsEmails.getByIndex(i));
+                i++;
             }
 
             final ExploreClubsOutputData outputData = new ExploreClubsOutputData(
-                    outputMap, false, student.getEmail(), joinedClubsEmails);
+                    outputMap, false, student.getEmail(), joinedEmails);
             exploreClubsPresenter.prepareSuccessView(outputData);
         }
     }

--- a/src/main/java/use_case/signup/club_signup/ClubSignupInteractor.java
+++ b/src/main/java/use_case/signup/club_signup/ClubSignupInteractor.java
@@ -3,6 +3,8 @@ package use_case.signup.club_signup;
 import entity.user.Club;
 import entity.user.ClubUserFactory;
 
+import java.util.ArrayList;
+
 /**
  * The Club Signup Interactor for the club sign up use case.
  */

--- a/src/main/java/use_case/student_homepage/dislike/StudentDislikeClubDataAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/dislike/StudentDislikeClubDataAccessInterface.java
@@ -1,5 +1,7 @@
 package use_case.student_homepage.dislike;
 
+import java.util.ArrayList;
+
 import entity.post.Post;
 import entity.user.Club;
 
@@ -22,4 +24,10 @@ public interface StudentDislikeClubDataAccessInterface {
      * @param post The post which is being disliked/ undisliked.
      */
     void savePost(Post post, Club club);
+
+    /**
+     * Gets the posts of a given club.
+     * @param club the club
+     */
+    ArrayList<Post> getPosts(Club club);
 }

--- a/src/main/java/use_case/student_homepage/dislike/StudentDislikeClubDataAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/dislike/StudentDislikeClubDataAccessInterface.java
@@ -19,6 +19,7 @@ public interface StudentDislikeClubDataAccessInterface {
     /**
      * Changes the dislike status in the post being interacted with (either likes if not previously liked,
      * or undislikes if
+     * PRECONDITION: the club already exists and has been saved before.
      * disliked), and saves the updated post to the db.
      * @param club The club which the post belongs to.
      * @param post The post which is being disliked/ undisliked.

--- a/src/main/java/use_case/student_homepage/dislike/StudentDislikeInteractor.java
+++ b/src/main/java/use_case/student_homepage/dislike/StudentDislikeInteractor.java
@@ -1,12 +1,11 @@
 package use_case.student_homepage.dislike;
 
+import java.util.ArrayList;
 import java.util.Map;
 
-import entity.data_structure.DataStoreArrays;
 import entity.post.Post;
 import entity.user.Club;
 import entity.user.Student;
-import interface_adapter.student_logged_in.student_home.dislike.StudentDislikePresenter;
 
 /**
  * Interactor for the dislike usecase.
@@ -26,12 +25,18 @@ public class StudentDislikeInteractor implements StudentDislikeInputBoundary {
 
     @Override
     public void execute(StudentDislikeInputData studentDislikeInputData) {
+        // Input data
         final String studentEmail = studentDislikeInputData.getStudentEmail();
         final String clubEmail = studentDislikeInputData.getClubEmail();
+        final Map<String, Object> postData = studentDislikeInputData.getPost();
+
+        // Get info from db
         final Student currStudent = studentDataAccess.getStudent(studentEmail);
         final Club currClub = clubDataAccess.getClub(clubEmail);
-        final Map<String, Object> postData = studentDislikeInputData.getPost();
-        final DataStoreArrays<Post> clubPosts = (DataStoreArrays<Post>) currClub.getClubPosts();
+
+        // Get the posts made by a club
+        final ArrayList<Post> clubPosts = clubDataAccess.getPosts(currClub);
+
         Post postObject = null;
         // Find the corresponding Post object for the data, using the date at which it was posted.
         for (final Post post: clubPosts) {
@@ -44,7 +49,7 @@ public class StudentDislikeInteractor implements StudentDislikeInputBoundary {
             studentDislikePresenter.prepareErrorView("The post doesn't exist");
         }
         else {
-            if (postObject.getDislikes().contains(currStudent)) {
+            if (postObject.getDislikes().contains(currStudent.getEmail())) {
                 postObject.removeDislike(currClub);
                 clubDataAccess.savePost(postObject, currClub);
             }
@@ -54,7 +59,8 @@ public class StudentDislikeInteractor implements StudentDislikeInputBoundary {
             }
             postData.put("disliked", !(Boolean) postData.get("disliked"));
 
-            final StudentDislikeOutputData studentDislikeOutputData = new StudentDislikeOutputData(postData, currClub.getUsername());
+            final StudentDislikeOutputData studentDislikeOutputData = new StudentDislikeOutputData(postData,
+                    currClub.getUsername());
             studentDislikePresenter.prepareSuccessView(studentDislikeOutputData);
         }
     }

--- a/src/main/java/use_case/student_homepage/like/StudentLikeClubDataAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/like/StudentLikeClubDataAccessInterface.java
@@ -1,5 +1,7 @@
 package use_case.student_homepage.like;
 
+import java.util.ArrayList;
+
 import entity.post.Post;
 import entity.user.Club;
 
@@ -22,4 +24,10 @@ public interface StudentLikeClubDataAccessInterface {
      * @param post The post which is being liked/ unliked.
      */
     void savePost(Post post, Club club);
+
+    /**
+     * Gets the posts of a given club.
+     * @param club the club
+     */
+    ArrayList<Post> getPosts(Club club);
 }

--- a/src/main/java/use_case/student_homepage/like/StudentLikeClubDataAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/like/StudentLikeClubDataAccessInterface.java
@@ -20,6 +20,7 @@ public interface StudentLikeClubDataAccessInterface {
     /**
      * Changes the like status in the post being interacted with (either likes if not previously liked, or unlikes if
      * liked), and saves the updated post to the db.
+     * PRECONDITION: the club already exists and has been saved before.
      * @param club The club which the post belongs to.
      * @param post The post which is being liked/ unliked.
      */

--- a/src/main/java/use_case/student_homepage/like/StudentLikeInteractor.java
+++ b/src/main/java/use_case/student_homepage/like/StudentLikeInteractor.java
@@ -1,5 +1,6 @@
 package use_case.student_homepage.like;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import entity.data_structure.DataStoreArrays;
@@ -25,14 +26,20 @@ public class StudentLikeInteractor implements StudentLikeInputBoundary {
 
     @Override
     public void execute(StudentLikeInputData studentLikeInputData) {
+        // Input data
         final String studentEmail = studentLikeInputData.getStudentEmail();
         final String clubEmail = studentLikeInputData.getClubEmail();
+        final Map<String, Object> postData = studentLikeInputData.getPost();
+
+        // DB info
         final Student currStudent = studentDataAccess.getStudent(studentEmail);
         final Club currClub = clubDataAccess.getClub(clubEmail);
-        final Map<String, Object> postData = studentLikeInputData.getPost();
-        final DataStoreArrays<Post> clubPosts = (DataStoreArrays<Post>) currClub.getClubPosts();
-        Post postObject = null;
+
+        // Get the posts made by a club
+        final ArrayList<Post> clubPosts = clubDataAccess.getPosts(currClub);
+
         // Find the corresponding Post object for the data, using the date at which it was posted.
+        Post postObject = null;
         for (final Post post: clubPosts) {
             if (post.dateOfPosting() == postData.get("date") && post.timeOfPosting() == postData.get("time")) {
                 postObject = post;
@@ -43,7 +50,8 @@ public class StudentLikeInteractor implements StudentLikeInputBoundary {
             studentLikePresenter.prepareErrorView("post does not exist");
         }
         else {
-            if (Boolean.TRUE.equals(postObject.getLikes().contains(currStudent))) {
+            if (Boolean.TRUE.equals(postObject.getLikes().contains(currStudent.getEmail()))) {
+                // Not the condition uses .getEmail due to the implementation of Post and the like instance variable.
                 postObject.removeLike(currStudent);
                 clubDataAccess.savePost(postObject, currClub);
             }
@@ -53,7 +61,8 @@ public class StudentLikeInteractor implements StudentLikeInputBoundary {
             }
             postData.put("liked", !(Boolean) postData.get("liked"));
 
-            final StudentLikeOutputData studentLikeOutputData = new StudentLikeOutputData(postData, currClub.getUsername());
+            final StudentLikeOutputData studentLikeOutputData = new StudentLikeOutputData(postData,
+                    currClub.getUsername());
             studentLikePresenter.prepareSuccessView(studentLikeOutputData);
         }
     }

--- a/src/main/java/use_case/student_homepage/like/StudentLikeInteractor.java
+++ b/src/main/java/use_case/student_homepage/like/StudentLikeInteractor.java
@@ -3,7 +3,6 @@ package use_case.student_homepage.like;
 import java.util.ArrayList;
 import java.util.Map;
 
-import entity.data_structure.DataStoreArrays;
 import entity.post.Post;
 import entity.user.Club;
 import entity.user.Student;

--- a/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsAccessInterface.java
@@ -1,5 +1,8 @@
 package use_case.student_homepage.show_clubs;
 
+import java.util.ArrayList;
+
+import entity.user.Club;
 import entity.user.Student;
 
 /**
@@ -20,4 +23,12 @@ public interface StudentShowClubsAccessInterface {
      * @return the student matching the email.
      */
     Student getStudent(String currentUser);
+
+    /**
+     * Gets the joined clubs for the given student.
+     * @param student the student
+     * @return an array lists of clubs
+     */
+    ArrayList<Club> getStudentJoinedClubs(Student student);
+
 }

--- a/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractor.java
+++ b/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractor.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import entity.data_structure.DataStoreArrays;
 import entity.user.Club;
+import entity.user.Student;
 
 /**
  * Interactor for the show clubs usecase.
@@ -27,10 +28,15 @@ public class StudentShowClubsInteractor implements StudentShowClubsInputBoundary
             showClubsPresenter.prepareFailView("The account does not exist.");
         }
         else {
-            final DataStoreArrays<Club> clubs = (DataStoreArrays<Club>) studentShowClubsAccessInterface.getStudent(
-                    currUserEmail).getJoinedClubs();
+            // Get Student
+            final Student student = studentShowClubsAccessInterface.getStudent(
+                    studentShowClubsInputData.getUserEmail());
+            // Get joined clubs
+            final ArrayList<Club> joinedClubs = studentShowClubsAccessInterface.getStudentJoinedClubs(student);
+
             final ArrayList<Map<String, String>> clubData = new ArrayList<>();
-            for (final Club club : clubs) {
+
+            for (final Club club : joinedClubs) {
                 final Map<String, String> singleClubData = new HashMap<>();
                 singleClubData.put("username", club.getUsername());
                 singleClubData.put("email", club.getEmail());

--- a/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractor.java
+++ b/src/main/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractor.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import entity.data_structure.DataStoreArrays;
 import entity.user.Club;
 import entity.user.Student;
 
@@ -43,7 +42,8 @@ public class StudentShowClubsInteractor implements StudentShowClubsInputBoundary
                 singleClubData.put("description", club.getClubDescription());
                 clubData.add(singleClubData);
             }
-            final StudentShowClubsOutputData studentShowClubsOutputData = new StudentShowClubsOutputData(clubData, currUserEmail);
+            final StudentShowClubsOutputData studentShowClubsOutputData = new StudentShowClubsOutputData(clubData,
+                    currUserEmail);
             showClubsPresenter.prepareClubsContent(studentShowClubsOutputData);
         }
     }

--- a/src/main/java/use_case/student_homepage/show_posts/StudentShowPostsClubAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/show_posts/StudentShowPostsClubAccessInterface.java
@@ -1,0 +1,18 @@
+package use_case.student_homepage.show_posts;
+
+import java.util.ArrayList;
+
+import entity.post.Post;
+import entity.user.Club;
+
+/**
+ * Data Access interface for the show clubs use case. This interface is dedicated to only club related DAO activities.
+ */
+public interface StudentShowPostsClubAccessInterface {
+    /**
+     * Gets the posts of a given club.
+     * @param club the club
+     */
+    ArrayList<Post> getPosts(Club club);
+
+}

--- a/src/main/java/use_case/student_homepage/show_posts/StudentShowPostsStudentAccessInterface.java
+++ b/src/main/java/use_case/student_homepage/show_posts/StudentShowPostsStudentAccessInterface.java
@@ -1,11 +1,14 @@
 package use_case.student_homepage.show_posts;
 
+import java.util.ArrayList;
+
+import entity.user.Club;
 import entity.user.Student;
 
 /**
  * Interface for the show posts usecase.
  */
-public interface StudentShowPostsAccessInterface {
+public interface StudentShowPostsStudentAccessInterface {
 
     /**
      * Checks if the email matches with a club in the database.
@@ -20,4 +23,11 @@ public interface StudentShowPostsAccessInterface {
      * @return the student matching the email.
      */
     Student getStudent(String currentUser);
+
+    /**
+     * Gets the joined clubs for the given student.
+     * @param student the student
+     * @return an array lists of clubs
+     */
+    ArrayList<Club> getStudentJoinedClubs(Student student);
 }

--- a/src/main/java/use_case/student_join_club/StudentJoinClubInteractor.java
+++ b/src/main/java/use_case/student_join_club/StudentJoinClubInteractor.java
@@ -37,7 +37,7 @@ public class StudentJoinClubInteractor implements StudentJoinClubInputBoundary {
             final Student student = studentJoinClubDataAccessInterface.getStudent(studentEmail);
 
             // Verify that student is not in club
-            if (club.getClubMembers().contains(student)) {
+            if (club.getClubMembersEmails().contains(student.getEmail())) {
                 joinClubPresenter.prepareFailView(studentEmail + ": Account in club already.");
             }
             else {

--- a/src/main/java/use_case/student_leave_club/StudentLeaveClubInteractor.java
+++ b/src/main/java/use_case/student_leave_club/StudentLeaveClubInteractor.java
@@ -37,7 +37,7 @@ public class StudentLeaveClubInteractor implements StudentLeaveClubInputBoundary
             final Student student = studentLeaveClubDataAccessInterface.getStudent(studentEmail);
 
             // Verify that student is in club
-            if (!club.getClubMembers().contains(student)) {
+            if (!club.getClubMembersEmails().contains(student.getEmail())) {
                 studentLeavePresenter.prepareFailView(studentEmail + ": Account not in club.");
             }
             else {

--- a/src/main/java/use_case/student_profile/StudentProfileInteractor.java
+++ b/src/main/java/use_case/student_profile/StudentProfileInteractor.java
@@ -1,5 +1,8 @@
 package use_case.student_profile;
 
+/**
+ * Interactor for the student profile use case.
+ */
 public class StudentProfileInteractor implements StudentProfileInputBoundary {
     private final StudentProfileOutputBoundary studentProfileOutputBoundary;
 

--- a/src/test/java/entity/post/PostEntityTest.java
+++ b/src/test/java/entity/post/PostEntityTest.java
@@ -2,9 +2,7 @@ package entity.post;
 
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.user.Club;
-import entity.user.Student;
-import entity.user.User;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -27,44 +25,48 @@ public class PostEntityTest {
 
     @Test
     void testLikePost() {
-        Post post = new Announcement("Sample Title", "Sample Content");
+        PostFactory factory = new AnnouncementFactory();
+        Post post = factory.create("Sample Title", "Sample Content");
 
-        DataStore<Club> joined = new DataStoreArrays<>();
-        User user = new Student("John Doe", "johndoe@example.com", "12345678hello", joined);
+        DataStore<String> joinedEmail = new DataStoreArrays<>();
+        DataStore<String> joinedName = new DataStoreArrays<>();
+        User user = new Student("John Doe", "johndoe@example.com", "12345678hello",
+                joinedEmail, joinedName );
 
         post.addLike(user);
         assertEquals(1, post.numberOfLikes());
-        assertTrue(post.getLikes().contains(user));
+        assertTrue(post.getLikes().contains(user.getEmail()));
 
         post.removeLike(user);
         assertEquals(0, post.numberOfLikes());
-        assertFalse(post.getLikes().contains(user));
+        assertFalse(post.getLikes().contains(user.getEmail()));
     }
 
     @Test
     void testDislikePost() {
-        Post post = new Announcement("Sample Title", "Sample Content");
-        DataStore<Club> joined = new DataStoreArrays<>();
-        User user = new Student("John Doe", "johndoe@example.com", "12345678hello", joined);
+        PostFactory factory = new AnnouncementFactory();
+        Post post = factory.create("Sample Title", "Sample Content");
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student user = studentFactory.create("John Doe", "johndoe@example.com", "12345678hello");
 
         post.addDislike(user);
         assertEquals(1, post.numberOfDislikes());
-        assertTrue(post.getDislikes().contains(user));
+        assertTrue(post.getDislikes().contains(user.getEmail()));
 
         post.removeDislike(user);
         assertEquals(0, post.numberOfDislikes());
-        assertFalse(post.getDislikes().contains(user));
+        assertFalse(post.getDislikes().contains(user.getEmail()));
     }
 
     @Test
     void testMultipleLikesAndDislikes() {
-        Post post = new Announcement("Title", "Content");
+        PostFactory factory = new AnnouncementFactory();
+        Post post = factory.create("Title", "Content");
 
-        DataStore<Club> joined1 = new DataStoreArrays<>();
-        User user1 = new Student("Alice", "alice@example.com", "12345678hello", joined1);
+        StudentFactory studentFactory = new StudentUserFactory();
+        User user1 = studentFactory.create("Alice", "alice@example.com", "12345678hello");
 
-        DataStore<Club> joined2 = new DataStoreArrays<>();
-        User user2 = new Student("Bob", "bob@example.com", "12345678hello", joined2);
+        User user2 = studentFactory.create("Bob", "bob@example.com", "12345678hello");
 
         post.addLike(user1);
         post.addLike(user2);
@@ -79,7 +81,8 @@ public class PostEntityTest {
 
     @Test
     void testPostMetadata() {
-        Post post = new Announcement("Metadata Title", "Metadata Content");
+        PostFactory factory = new AnnouncementFactory();
+        Post post = factory.create("Metadata Title", "Metadata Content");
 
         LocalDate today = LocalDate.now();
         LocalTime now = LocalTime.now();

--- a/src/test/java/entity/user/ClubTests.java
+++ b/src/test/java/entity/user/ClubTests.java
@@ -6,7 +6,10 @@ import entity.post.Announcement;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 
@@ -20,189 +23,99 @@ public class ClubTests {
 
     @Test
     public void testClubCreation() {
-        // Initialize the club factory
-        ClubFactory clubFactory = new ClubUserFactory();
+        // Create a club factory
+        final ClubFactory clubFactory = new ClubUserFactory();
 
-        // Create a Club
+        // Create a test club
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
-        // Verify that the instance variables are correct
-        assertEquals(clubName, testClub.getUsername());
-        assertEquals(clubEmail, testClub.getEmail());
-        assertEquals(clubPassword, testClub.getPassword());
+        // verify that all the data matches
+        assertNotNull(testClub);
+        assertEquals(testClub.getUsername(), clubName);
+        assertEquals(testClub.getEmail(), clubEmail);
+        assertEquals(testClub.getPassword(), clubPassword);
         assertEquals("", testClub.getClubDescription());
 
-        // Verify that the setter method work
-        testClub.setClubDescription("Test Club Description");
-        assertEquals("Test Club Description", testClub.getClubDescription());
+        // Since it is a new club, there should be no posts and not members
+        int sizeMembersEmails = testClub.getClubMembersEmails().size();
+        assertEquals(0, sizeMembersEmails);
 
-        // Create other club
-        DataStore<Student> members = new DataStoreArrays<>();
-        DataStore<Post> announcements = new DataStoreArrays<>();
+        int sizeMembersNames = testClub.getClubMembersNames().size();
+        assertEquals(0, sizeMembersNames);
 
-        // Add
-        StudentFactory studentFactory = new StudentUserFactory();
-        members.add(studentFactory.create("test", "test@gmail.com", "test1234"));
-        members.add(studentFactory.create("test2", "test@gmail.com2", "test12342", new DataStoreArrays<>()));
-        PostFactory postFactory = new AnnouncementFactory();
-        announcements.add(postFactory.create("testead", "testead"));
-        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword, members, announcements);
+        int sizePostTitles = testClub.getClubPostsTitle().size();
+        assertEquals(0, sizePostTitles);
 
-        // Verify
-        assertEquals(clubName, testClub2.getUsername());
-        assertEquals(clubEmail, testClub2.getEmail());
-        assertEquals(clubPassword, testClub2.getPassword());
-        assertEquals("", testClub2.getClubDescription());
-        int sizeMember = testClub2.getClubMembers().size();
-        assertEquals(2, sizeMember);
-        int sizePost = testClub2.getClubPosts().size();
-        assertEquals(1, sizePost);
-    }
+        int sizePostDescriptions = testClub.getClubPostsDescription().size();
+        assertEquals(0, sizePostDescriptions);
 
-    @Test
-    public void testClubMembers() {
-        String studentUsername = "student";
-        String studentEmail = "student@email.com";
-        String studentPassword = "student12345";
-
-        // Initialize the student factory
-        StudentFactory studentFactory = new StudentUserFactory();
-
-        // Create the student
-        Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
-
-        // Verify that the instance variables hold true
-        assertEquals(studentUsername, testStudent.getUsername());
-        assertEquals(studentEmail, testStudent.getEmail());
-        assertEquals(studentPassword, testStudent.getPassword());
-
-        // Create new student
-        ClubFactory clubFactory = new ClubUserFactory();
-        Club testClub = clubFactory.create("test", "test@gmail.com", "test1234");
-        DataStore<Club> members = new DataStoreArrays<>();
-        members.add(testClub);
-        Student newStudent = studentFactory.create(studentUsername, studentEmail, studentPassword, members);
-
-        // Test
-        assertEquals(studentUsername, newStudent.getUsername());
-        assertEquals(studentEmail, newStudent.getEmail());
-        assertEquals(studentPassword, newStudent.getPassword());
-        int sizeJoinedClubs = newStudent.getJoinedClubs().size();
-        assertEquals(1, sizeJoinedClubs);
-
-        // Create the student
-        Student testStudent2 = studentFactory.create(studentUsername, studentEmail, studentPassword);
-
-        // Create 10 clubs for the student to join
-        Club clubToRemove = null;
-        for (int i = 0; i < 10; i++) {
-            Club club = clubFactory.create("club" + i,
-                    "club" + i + "@gmail.com", "password" + i);
-            testStudent2.joinClub(club);
-            clubToRemove = club;
-        }
-
-        // Check that there are 10 clubs joined
-        int sizeClubsJoined = testStudent2.getJoinedClubs().size();
-        assertEquals(10, sizeClubsJoined);
-
-        // Leave club
-        testStudent2.leaveClub(clubToRemove);
-
-        // Check new size
-        int sizeClubsLeave = testStudent2.getJoinedClubs().size();
-        assertEquals(9, sizeClubsLeave);
-
-        // Check the club is no longer in clubs joined
-        DataStore<Club> joinedClubs = testStudent2.getJoinedClubs();
-        int index = 0;
-        while (index < joinedClubs.size()) {
-            // Check that the left club is no longer in the joined clubs by checking the unique username and password
-            Club clubAtIndex = joinedClubs.getByIndex(index);
-            assertNotEquals(clubToRemove.getEmail(), clubAtIndex.getEmail());
-            assertNotEquals(clubToRemove.getUsername(), clubAtIndex.getUsername());
-            index++;
-        }
+        testClub.setClubDescription("new");
+        assertEquals("new", testClub.getClubDescription());
     }
 
     @Test
     public void testClubMemberManipulation() {
         // Initialize the club factory
-        ClubFactory clubFactory = new ClubUserFactory();
+        final ClubFactory clubFactory = new ClubUserFactory();
 
-        // Create a Club
+        // Create a test club
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
-        // Test the members
+        // Create and add 10 members
         StudentFactory studentFactory = new StudentUserFactory();
-        Student studentToRemove = null;
+        ArrayList<Student> tracker = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Student student = studentFactory.create("member" + i, "member" + i +"@gmail.com",
-                    "password" + i);
+            Student student = studentFactory.create("members" + String.valueOf(i),
+                    "member@" + String.valueOf(i), "123123123");
             testClub.addClubMember(student);
-            studentToRemove = student;
+            tracker.add(student);
         }
-        // Check that there are 10 members
-        int sizeMembers = testClub.getClubMembers().size();
-        assertEquals(10, sizeMembers);
+        int sizeMembersEmails = testClub.getClubMembersEmails().size();
+        int sizeMembersNames = testClub.getClubMembersNames().size();
+        assertEquals(10, sizeMembersEmails);
+        assertEquals(10, sizeMembersNames);
 
-        // Remove Student
-        testClub.removeClubMember(studentToRemove);
-
-        // Check new size
-        int sizeMembersAfterRemove = testClub.getClubMembers().size();
-        assertEquals(9, sizeMembersAfterRemove);
-
-        // Check if member is out
-        DataStore<Student> members = testClub.getClubMembers();
-        int index = 0;
-        while (index < members.size()) {
-            Student studentAtIndex = members.getByIndex(index);
-            // Check for name and password since they are in theory unique.
-            assertNotEquals(studentToRemove.getEmail(), studentAtIndex.getEmail());
-            assertNotEquals(studentToRemove.getUsername(), studentAtIndex.getUsername());
-            index++;
+        // Check that the name match and remove the members
+        for (int i = 0; i < 10; i++) {
+            assertEquals(testClub.getClubMembersEmails().getByIndex(i), "members@" + String.valueOf(i));
+            assertEquals(testClub.getClubMembersNames().getByIndex(i), "members" + String.valueOf(i));
+            testClub.removeClubMember(tracker.get(i));
         }
+        int sizeAfterRemoveEmails = testClub.getClubMembersEmails().size();
+        assertEquals(0, sizeAfterRemoveEmails);
+
+        int sizeAfterRemoveName = testClub.getClubMembersNames().size();
+        assertEquals(0, sizeAfterRemoveName);
     }
 
     @Test
     public void testClubPostManipulation() {
         // Initialize the club factory
-        ClubFactory clubFactory = new ClubUserFactory();
+        final ClubFactory clubFactory = new ClubUserFactory();
 
-        // Create a Club
+        // Create a test club
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
-        // Create 10 club posts
-        PostFactory postFactory = new AnnouncementFactory();
-        Post postToRemove = null;
+        // Create and add 10 posts
+        AnnouncementFactory announcementFactory = new AnnouncementFactory();
+        ArrayList<Post> tracker = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Post post = postFactory.create("post" + i, "description" + i);
+            Post post = announcementFactory.create("post" + String.valueOf(i),
+                    "content" + String.valueOf(i));
             testClub.addClubPost(post);
-            postToRemove = post;
+            tracker.add(post);
         }
 
-        // Check that there are 10 posts
-        int sizePosts = testClub.getClubPosts().size();
-        assertEquals(10, sizePosts);
+        int sizePostTitles = testClub.getClubPostsTitle().size();
+        int sizePostDescriptions = testClub.getClubPostsDescription().size();
+        assertEquals(10, sizePostTitles);
+        assertEquals(10, sizePostDescriptions);
 
-        // Remove post
-        testClub.removeClubPost(postToRemove);
-
-        // Check new size
-        int sizePostsAfterRemove = testClub.getClubPosts().size();
-        assertEquals(9, sizePostsAfterRemove);
-
-        // Check if post is out
-        DataStore<Post> posts = testClub.getClubPosts();
-        int index = 0;
-        while (index < posts.size()) {
-            Post postAtIndex = posts.getByIndex(index);
-
-            // Verify that no posts has the same exact title and description
-            assertTrue(!postToRemove.getTitle().equals(postAtIndex.getTitle()) &&
-                    !postToRemove.getContent().equals(postAtIndex.getContent()));
-            index++;
+        // Check that the name match and remove the members
+        for (int i = 0; i < 10; i++) {
+            assertEquals(testClub.getClubPostsTitle().getByIndex(i), "post" + String.valueOf(i));
+            assertEquals(testClub.getClubPostsDescription().getByIndex(i), "content" + String.valueOf(i));
+            testClub.removeClubPost(tracker.get(i));
         }
     }
 }

--- a/src/test/java/entity/user/ClubTests.java
+++ b/src/test/java/entity/user/ClubTests.java
@@ -66,7 +66,7 @@ public class ClubTests {
         ArrayList<Student> tracker = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             Student student = studentFactory.create("members" + String.valueOf(i),
-                    "member@" + String.valueOf(i), "123123123");
+                    "members@" + String.valueOf(i), "123123123");
             testClub.addClubMember(student);
             tracker.add(student);
         }
@@ -79,6 +79,10 @@ public class ClubTests {
         for (int i = 0; i < 10; i++) {
             assertEquals(testClub.getClubMembersEmails().getByIndex(i), "members@" + String.valueOf(i));
             assertEquals(testClub.getClubMembersNames().getByIndex(i), "members" + String.valueOf(i));
+        }
+
+        // Remove all members
+        for (int i = 0; i < 10; i++) {
             testClub.removeClubMember(tracker.get(i));
         }
         int sizeAfterRemoveEmails = testClub.getClubMembersEmails().size();

--- a/src/test/java/entity/user/StudentTest.java
+++ b/src/test/java/entity/user/StudentTest.java
@@ -7,6 +7,8 @@ import entity.post.Post;
 import entity.post.PostFactory;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+
 import static org.junit.Assert.*;
 
 /**
@@ -18,194 +20,63 @@ public class StudentTest {
     static String studentPassword = "student12345";
 
     @Test
-    public void testStudentCreation() {
+    public void testStudent() {
         // Initialize the student factory
         StudentFactory studentFactory = new StudentUserFactory();
 
-        // Create the student
-        Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
+        // Create a test student
+        Student student = studentFactory.create(studentUsername, studentEmail, studentPassword);
 
-        // Verify that the instance variables hold true
-        assertEquals(studentUsername, testStudent.getUsername());
-        assertEquals(studentEmail, testStudent.getEmail());
-        assertEquals(studentPassword, testStudent.getPassword());
+        // Check data
+        assertNotNull(student);
+        assertEquals(student.getUsername(), studentUsername);
+        assertEquals(student.getEmail(), studentEmail);
+        assertEquals(student.getPassword(), studentPassword);
 
-        // Create new student
-        ClubFactory clubFactory = new ClubUserFactory();
-        Club testClub = clubFactory.create("test", "test@gmail.com", "test1234");
-        DataStore<Club> members = new DataStoreArrays<>();
-        members.add(testClub);
-        Student newStudent = studentFactory.create(studentUsername, studentEmail, studentPassword, members);
+        // Check that the clubs joined is empty since the student profile just got created
+        int sizeClubNames = student.getJoinedClubsNames().size();
+        int sizeClubEmails = student.getJoinedClubsEmails().size();
 
-        // Test
-        assertEquals(studentUsername, newStudent.getUsername());
-        assertEquals(studentEmail, newStudent.getEmail());
-        assertEquals(studentPassword, newStudent.getPassword());
-        int sizeJoinedClubs = newStudent.getJoinedClubs().size();
-        assertEquals(1, sizeJoinedClubs);
+        assertEquals(sizeClubNames, 0);
+        assertEquals(sizeClubEmails, 0);
     }
 
     @Test
-    public void testStudentJoinClub() {
+    public void testClubManipulation() {
         // Initialize the student factory
         StudentFactory studentFactory = new StudentUserFactory();
 
-        // Create the student
-        Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
+        // Create a test student
+        Student student = studentFactory.create(studentUsername, studentEmail, studentPassword);
 
-        // Create 10 clubs for the student to join
+        // Create 10 clubs to join
         ClubFactory clubFactory = new ClubUserFactory();
-        Club clubToRemove = null;
+        ArrayList<Club> tracker = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Club club = clubFactory.create("club" + i,
-                    "club" + i + "@gmail.com", "password" + i);
-            testStudent.joinClub(club);
-            clubToRemove = club;
+            Club club = clubFactory.create("club" + String.valueOf(i), "club@" + String.valueOf(i),
+                    "club" + String.valueOf(i));
+            student.joinClub(club);
+            tracker.add(club);
         }
 
-        // Check that there are 10 clubs joined
-        int sizeClubsJoined = testStudent.getJoinedClubs().size();
-        assertEquals(10, sizeClubsJoined);
+        int sizeClubNames = student.getJoinedClubsNames().size();
+        int sizeClubEmails = student.getJoinedClubsEmails().size();
 
-        // Leave club
-        testStudent.leaveClub(clubToRemove);
+        assertEquals(sizeClubNames, 10);
+        assertEquals(sizeClubEmails, 10);
 
-        // Check new size
-        int sizeClubsLeave = testStudent.getJoinedClubs().size();
-        assertEquals(9, sizeClubsLeave);
-
-        // Check the club is no longer in clubs joined
-        DataStore<Club> joinedClubs = testStudent.getJoinedClubs();
-        int index = 0;
-        while (index < joinedClubs.size()) {
-            // Check that the left club is no longer in the joined clubs by checking the unique username and password
-            Club clubAtIndex = joinedClubs.getByIndex(index);
-            assertNotEquals(clubToRemove.getEmail(), clubAtIndex.getEmail());
-            assertNotEquals(clubToRemove.getUsername(), clubAtIndex.getUsername());
-            index++;
-        }
-    }
-
-    @Test
-    public void testStudentClubManipulation() {
-        String clubName = "Test Club Name";
-        String clubEmail = "club@email.com";
-        String clubPassword = "TestClubPassword123";
-        // Initialize the club factory
-        ClubFactory clubFactory = new ClubUserFactory();
-
-        // Create a Club
-        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
-
-        // Verify that the instance variables are correct
-        assertEquals(clubName, testClub.getUsername());
-        assertEquals(clubEmail, testClub.getEmail());
-        assertEquals(clubPassword, testClub.getPassword());
-        assertEquals("", testClub.getClubDescription());
-
-        // Verify that the setter method work
-        testClub.setClubDescription("Test Club Description");
-        assertEquals("Test Club Description", testClub.getClubDescription());
-
-        // Create other club
-        DataStore<Student> members = new DataStoreArrays<>();
-        DataStore<Post> announcements = new DataStoreArrays<>();
-
-        // Add
-        StudentFactory studentFactory = new StudentUserFactory();
-        members.add(studentFactory.create("test", "test@gmail.com", "test1234"));
-        members.add(studentFactory.create("test2", "test@gmail.com2", "test12342", new DataStoreArrays<>()));
-        PostFactory postFactory = new AnnouncementFactory();
-        announcements.add(postFactory.create("testead", "testead"));
-        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword, members, announcements);
-
-        // Verify
-        assertEquals(clubName, testClub2.getUsername());
-        assertEquals(clubEmail, testClub2.getEmail());
-        assertEquals(clubPassword, testClub2.getPassword());
-        assertEquals("", testClub2.getClubDescription());
-        int sizeMember = testClub2.getClubMembers().size();
-        assertEquals(2, sizeMember);
-        int sizePost = testClub2.getClubPosts().size();
-        assertEquals(1, sizePost);
-    }
-
-    @Test
-    public void testStudentPostManipulation() {
-        String clubName = "Test Club Name";
-        String clubEmail = "club@email.com";
-        String clubPassword = "TestClubPassword123";
-
-        // Initialize the club factory
-        ClubFactory clubFactory = new ClubUserFactory();
-
-        // Create a Club
-        Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
-
-        // Test the members
-        StudentFactory studentFactory = new StudentUserFactory();
-        Student studentToRemove = null;
+        // Check that the name match and leave the club
         for (int i = 0; i < 10; i++) {
-            Student student = studentFactory.create("member" + i, "member" + i +"@gmail.com",
-                    "password" + i);
-            testClub.addClubMember(student);
-            studentToRemove = student;
-        }
-        // Check that there are 10 members
-        int sizeMembers = testClub.getClubMembers().size();
-        assertEquals(10, sizeMembers);
-
-        // Remove Student
-        testClub.removeClubMember(studentToRemove);
-
-        // Check new size
-        int sizeMembersAfterRemove = testClub.getClubMembers().size();
-        assertEquals(9, sizeMembersAfterRemove);
-
-        // Check if member is out
-        DataStore<Student> members = testClub.getClubMembers();
-        int index = 0;
-        while (index < members.size()) {
-            Student studentAtIndex = members.getByIndex(index);
-            // Check for name and password since they are in theory unique.
-            assertNotEquals(studentToRemove.getEmail(), studentAtIndex.getEmail());
-            assertNotEquals(studentToRemove.getUsername(), studentAtIndex.getUsername());
-            index++;
+            assertEquals(tracker.get(i).getEmail(), student.getJoinedClubsEmails().getByIndex(i));
+            assertEquals(tracker.get(i).getUsername(), student.getJoinedClubsNames().getByIndex(i));
+            student.leaveClub(tracker.get(i));
         }
 
-        // Create a Club
-        Club testClub2 = clubFactory.create(clubName, clubEmail, clubPassword);
+        int sizeClubNamesAfter = student.getJoinedClubsNames().size();
+        int sizeClubEmailsAfter = student.getJoinedClubsEmails().size();
 
-        // Create 10 club posts
-        PostFactory postFactory = new AnnouncementFactory();
-        Post postToRemove = null;
-        for (int i = 0; i < 10; i++) {
-            Post post = postFactory.create("post" + i, "description" + i);
-            testClub2.addClubPost(post);
-            postToRemove = post;
-        }
+        assertEquals(sizeClubNamesAfter, 0);
+        assertEquals(sizeClubEmailsAfter, 0);
 
-        // Check that there are 10 posts
-        int sizePosts = testClub2.getClubPosts().size();
-        assertEquals(10, sizePosts);
-
-        // Remove post
-        testClub2.removeClubPost(postToRemove);
-
-        // Check new size
-        int sizePostsAfterRemove = testClub2.getClubPosts().size();
-        assertEquals(9, sizePostsAfterRemove);
-
-        // Check if post is out
-        DataStore<Post> posts = testClub2.getClubPosts();
-        int index2 = 0;
-        while (index2 < posts.size()) {
-            Post postAtIndex = posts.getByIndex(index2);
-
-            // Verify that no posts has the same exact title and description
-            assertTrue(!postToRemove.getTitle().equals(postAtIndex.getTitle()) &&
-                    !postToRemove.getContent().equals(postAtIndex.getContent()));
-            index2++;
-        }
     }
 }

--- a/src/test/java/entity/user/StudentTest.java
+++ b/src/test/java/entity/user/StudentTest.java
@@ -69,6 +69,10 @@ public class StudentTest {
         for (int i = 0; i < 10; i++) {
             assertEquals(tracker.get(i).getEmail(), student.getJoinedClubsEmails().getByIndex(i));
             assertEquals(tracker.get(i).getUsername(), student.getJoinedClubsNames().getByIndex(i));
+        }
+
+        // Make everyone leave the club and check
+        for (int i = 0; i < 10; i++) {
             student.leaveClub(tracker.get(i));
         }
 

--- a/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
+++ b/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_create_post;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.Club;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
@@ -27,7 +27,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -88,7 +88,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -131,7 +131,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -174,7 +174,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         final String postTitle = "";
         final String postDescription = "Test Post Description for empty title";
@@ -222,7 +222,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         final String postTitle = "Test Post Title";
         final String postDescription = "";
@@ -270,7 +270,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         final String postTitle = "";
         final String postDescription = "";
@@ -318,7 +318,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         String postTitle = "this is 100 characters long because I know it is and if I am not mistaken this " +
                 "should be 100 charact";
@@ -369,7 +369,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         String postDescription = "this is 100 characters long because I know it is and if I am not mistaken this " +
                 "should be 100 charact";

--- a/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
+++ b/src/test/java/use_case/club_create_post/ClubCreatePostInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_create_post;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Club;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
@@ -27,7 +27,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -75,7 +75,7 @@ public class ClubCreatePostInteractorTest {
         for (ClubCreatePostInputData inputData : inputs) {
             interactor.execute(inputData);
         }
-        int sizePosts = userRepository.getClub(testClub.getEmail()).getClubPosts().size();
+        int sizePosts = userRepository.getClub(testClub.getEmail()).getClubPostsTitle().size();
         assertEquals(10, sizePosts);
     }
 
@@ -88,7 +88,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -131,7 +131,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
 
         // Save the club to the in memory DAO/Database
@@ -174,7 +174,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         final String postTitle = "";
         final String postDescription = "Test Post Description for empty title";
@@ -222,7 +222,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         final String postTitle = "Test Post Title";
         final String postDescription = "";
@@ -270,7 +270,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         final String postTitle = "";
         final String postDescription = "";
@@ -318,7 +318,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         String postTitle = "this is 100 characters long because I know it is and if I am not mistaken this " +
                 "should be 100 charact";
@@ -369,7 +369,7 @@ public class ClubCreatePostInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         String postDescription = "this is 100 characters long because I know it is and if I am not mistaken this " +
                 "should be 100 charact";

--- a/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
+++ b/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_get_members;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +36,7 @@ public class ClubGetMembersInteractorTest {
         }
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Save the club to the in memory DAO/Database
         userRepository.saveClub(testClub);
@@ -95,7 +95,7 @@ public class ClubGetMembersInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Add 10 test members to the club.
         ArrayList<Student> verificationList = new ArrayList<>();
@@ -141,7 +141,7 @@ public class ClubGetMembersInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Save the club to the in memory DAO/Database
         userRepository.saveClub(testClub);

--- a/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
+++ b/src/test/java/use_case/club_get_members/ClubGetMembersInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_get_members;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +36,7 @@ public class ClubGetMembersInteractorTest {
         }
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Save the club to the in memory DAO/Database
         userRepository.saveClub(testClub);
@@ -95,7 +95,7 @@ public class ClubGetMembersInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Add 10 test members to the club.
         ArrayList<Student> verificationList = new ArrayList<>();
@@ -141,7 +141,7 @@ public class ClubGetMembersInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Save the club to the in memory DAO/Database
         userRepository.saveClub(testClub);

--- a/src/test/java/use_case/club_get_posts/ClubGetPostsInteractorTest.java
+++ b/src/test/java/use_case/club_get_posts/ClubGetPostsInteractorTest.java
@@ -1,11 +1,14 @@
 package use_case.club_get_posts;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
 import entity.post.Announcement;
+import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.user.Club;
+import entity.user.ClubFactory;
+import entity.user.ClubUserFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,13 +17,18 @@ public class ClubGetPostsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
-        // Add a club in the DAO that has a post
-        DataStore<Post> posts = new DataStoreArrays<>();
-        posts.add(new Announcement("title", "content"));
-        posts.add(new Announcement("title2", "content2"));
-        userRepository.saveClub(new Club("Roy", "ok@k.com", "password", null, posts));
+
+        // Initialize Post factory
+        AnnouncementFactory announcementFactory = new AnnouncementFactory();
+
+        // Initialize club factory
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Roy", "ok@k.com", "password");
+        club.addClubPost(announcementFactory.create("title", "content"));
+        club.addClubPost(announcementFactory.create("title2", "content2"));
+        userRepository.saveClub(club);
 
         ClubGetPostsInputData inputData = new ClubGetPostsInputData("ok@k.com");
 
@@ -50,7 +58,7 @@ public class ClubGetPostsInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with no clubs
-        ClubGetPostsDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubGetPostsDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         ClubGetPostsInputData inputData = new ClubGetPostsInputData("ok@k.com");
 

--- a/src/test/java/use_case/club_get_posts/ClubGetPostsInteractorTest.java
+++ b/src/test/java/use_case/club_get_posts/ClubGetPostsInteractorTest.java
@@ -1,11 +1,7 @@
 package use_case.club_get_posts;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
-import entity.post.Announcement;
+import data_access.InMemoryUserDataAccessObject;
 import entity.post.AnnouncementFactory;
-import entity.post.Post;
 import entity.user.Club;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
@@ -17,7 +13,7 @@ public class ClubGetPostsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
 
         // Initialize Post factory
@@ -58,7 +54,7 @@ public class ClubGetPostsInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with no clubs
-        ClubGetPostsDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubGetPostsDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         ClubGetPostsInputData inputData = new ClubGetPostsInputData("ok@k.com");
 

--- a/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
+++ b/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_remove_member;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.data_structure.DataStore;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -110,7 +110,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Add 1 student for the sake fo this test
         ArrayList<Student> membersList = new ArrayList<>();
@@ -164,7 +164,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -219,7 +219,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -270,7 +270,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the student which is not a member of the club.
         String wrongEmail = "wrong@email.com";

--- a/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
+++ b/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.club_remove_member;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -61,13 +61,15 @@ public class ClubRemoveMemberInteractorTest {
 
                 // Get the updated members
                 Club updatedClub = userRepository.getClub(clubEmail);
-                DataStore<Student> members = updatedClub.getClubMembers();
+
+                DataStore<String> membersName = updatedClub.getClubMembersNames();
+                DataStore<String> membersEmail = updatedClub.getClubMembersEmails();
 
                 // Verify that every student in the members list is
                 int index = 0;
-                while (index < members.size()) {
-                    String studentEmail = members.getByIndex(index).getEmail();
-                    String studentUsername = members.getByIndex(index).getUsername();
+                while (index < membersName.size()) {
+                    String studentEmail = membersEmail.getByIndex(index);
+                    String studentUsername = membersName.getByIndex(index);
 
                     // We check the email first since it is unique.
                     assertNotEquals(outputData.getStudentEmail(), studentEmail);
@@ -94,7 +96,7 @@ public class ClubRemoveMemberInteractorTest {
         }
 
         // Check that the club has no members since we in theory removed all members
-        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembers().size();
+        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembersEmails().size();
         assertEquals(0, numberOfMembers);
     }
 
@@ -108,7 +110,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Add 1 student for the sake fo this test
         ArrayList<Student> membersList = new ArrayList<>();
@@ -131,10 +133,12 @@ public class ClubRemoveMemberInteractorTest {
 
                 // Get the members of the updated club;
                 Club updatedClub = userRepository.getClub(clubEmail);
-                DataStore<Student> members = updatedClub.getClubMembers();
+
+                DataStore<String> membersName = updatedClub.getClubMembersNames();
+                DataStore<String> membersEmail = updatedClub.getClubMembersEmails();
 
                 // Check that the removed member is not in the members list of the club
-                int size = members.size();
+                int size = membersEmail.size();
                 assertEquals(0, size);
             }
 
@@ -160,7 +164,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -201,7 +205,7 @@ public class ClubRemoveMemberInteractorTest {
                 userRepository, failurePresenter);
         interactor.execute(inputData);
 
-        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembers().size();
+        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembersEmails().size();
         assertEquals(10, numberOfMembers);
     }
 
@@ -215,7 +219,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Add 10 test members to the club and save the students.
         ArrayList<Student> membersList = new ArrayList<>();
@@ -252,7 +256,7 @@ public class ClubRemoveMemberInteractorTest {
                 userRepository, failurePresenter);
         interactor.execute(inputData);
 
-        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembers().size();
+        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembersEmails().size();
         assertEquals(10, numberOfMembers);
     }
 
@@ -266,7 +270,7 @@ public class ClubRemoveMemberInteractorTest {
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the student which is not a member of the club.
         String wrongEmail = "wrong@email.com";
@@ -297,7 +301,7 @@ public class ClubRemoveMemberInteractorTest {
                 userRepository, failurePresenter);
         interactor.execute(inputData);
 
-        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembers().size();
+        int numberOfMembers = userRepository.getClub(clubEmail).getClubMembersEmails().size();
         assertEquals(0, numberOfMembers);
 
     }

--- a/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
+++ b/src/test/java/use_case/club_remove_member/ClubRemoveMemberInteractorTest.java
@@ -77,7 +77,7 @@ public class ClubRemoveMemberInteractorTest {
                     // We check the username second since they are also unique.
                     assertNotEquals(outputData.getStudentUsername(),studentUsername);
 
-                    // Increment
+                     // Increment
                     index++;
                 }
             }

--- a/src/test/java/use_case/club_update_desc/ClubUpdateDescInteractorTest.java
+++ b/src/test/java/use_case/club_update_desc/ClubUpdateDescInteractorTest.java
@@ -1,7 +1,6 @@
 package use_case.club_update_desc;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.user.Club;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,7 @@ public class ClubUpdateDescInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Initialize the club factory
         ClubFactory clubFactory = new ClubUserFactory();
@@ -44,7 +43,7 @@ public class ClubUpdateDescInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case
-        ClubUpdateDescDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubUpdateDescDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         ClubUpdateDescInputData inputData = new ClubUpdateDescInputData("ok@k.com", "test");
 

--- a/src/test/java/use_case/club_update_desc/ClubUpdateDescInteractorTest.java
+++ b/src/test/java/use_case/club_update_desc/ClubUpdateDescInteractorTest.java
@@ -1,7 +1,9 @@
 package use_case.club_update_desc;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Club;
+import entity.user.ClubFactory;
+import entity.user.ClubUserFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,8 +14,11 @@ public class ClubUpdateDescInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
-        userRepository.saveClub(new Club("Roy", "ok@k.com", "password", null, null));
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+
+        // Initialize the club factory
+        ClubFactory clubFactory = new ClubUserFactory();
+        userRepository.saveClub(clubFactory.create("Roy", "ok@k.com", "password"));
 
         ClubUpdateDescInputData inputData = new ClubUpdateDescInputData("ok@k.com", "test");
 
@@ -39,7 +44,7 @@ public class ClubUpdateDescInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case
-        ClubUpdateDescDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubUpdateDescDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         ClubUpdateDescInputData inputData = new ClubUpdateDescInputData("ok@k.com", "test");
 

--- a/src/test/java/use_case/explore_clubs/ExploreClubsInteractorTest.java
+++ b/src/test/java/use_case/explore_clubs/ExploreClubsInteractorTest.java
@@ -1,10 +1,9 @@
 package use_case.explore_clubs;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -16,19 +15,18 @@ public class ExploreClubsInteractorTest {
     @Test
     void successTest() {
         // In-memory data setup
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
         // Create clubs
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        DataStore<Student> students2 = new DataStoreArrays<Student>();
-        Club club1 = new Club("Club1", "club1@example.com", "password1", students1, null);
-        Club club2 = new Club("Club2", "club2@example.com", "password2", students2, null);
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club1 = clubFactory.create("Club1", "club1@example.com", "password1");
+        Club club2 = clubFactory.create("Club2", "club2@example.com", "password2");
         club1.setClubDescription("Description1");
         club2.setClubDescription("Description2");
 
         // Create a student and associate with one club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        joinedClubs.add(club1);
-        Student student = new Student("Student1", "student1@example.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Student1", "student1@example.com", "password");
+        student.joinClub(club1);
         club1.addClubMember(student);
 
         userRepository.saveStudent(student);
@@ -81,7 +79,7 @@ public class ExploreClubsInteractorTest {
     @Test
     void failTest() {
         // In-memory data setup
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Input data for a non-existent student
         ExploreClubsInputData inputData = new ExploreClubsInputData("nonexistent@example.com");

--- a/src/test/java/use_case/explore_clubs/ExploreClubsInteractorTest.java
+++ b/src/test/java/use_case/explore_clubs/ExploreClubsInteractorTest.java
@@ -1,8 +1,6 @@
 package use_case.explore_clubs;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +13,7 @@ public class ExploreClubsInteractorTest {
     @Test
     void successTest() {
         // In-memory data setup
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
         // Create clubs
         ClubFactory clubFactory = new ClubUserFactory();
         Club club1 = clubFactory.create("Club1", "club1@example.com", "password1");
@@ -79,7 +77,7 @@ public class ExploreClubsInteractorTest {
     @Test
     void failTest() {
         // In-memory data setup
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Input data for a non-existent student
         ExploreClubsInputData inputData = new ExploreClubsInputData("nonexistent@example.com");

--- a/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
+++ b/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.login.club_login;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Club;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
@@ -23,7 +23,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -50,8 +50,8 @@ public class ClubLoginInteractorTest {
                 assertEquals(dbClub.getUsername(), clubLoginOutputData.getUsername());
 
                 // Check that the db club has no posts and members (since new club)
-                int sizeMembers = dbClub.getClubMembers().size();
-                int sizePosts = dbClub.getClubPosts().size();
+                int sizeMembers = dbClub.getClubMembersEmails().size();
+                int sizePosts = dbClub.getClubPostsTitle().size();
                 assertEquals(0, sizeMembers);
                 assertEquals(0, sizePosts);
 
@@ -80,7 +80,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -121,7 +121,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -161,7 +161,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -201,7 +201,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);

--- a/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
+++ b/src/test/java/use_case/login/club_login/ClubLoginInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.login.club_login;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.Club;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
@@ -23,7 +23,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -80,7 +80,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -121,7 +121,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -161,7 +161,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);
@@ -201,7 +201,7 @@ public class ClubLoginInteractorTest {
         ClubFactory clubFactory = new ClubUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club (sign up)
         Club testClub = clubFactory.create(clubName, clubEmail, clubPassword);

--- a/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
+++ b/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.login.student_login;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Student;
 import entity.user.StudentFactory;
 import entity.user.StudentUserFactory;
@@ -24,7 +24,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -51,7 +51,7 @@ public class StudentLoginInteractorTest {
                 assertEquals(dbStudent.getUsername(), studentLoginOutputData.getUsername());
 
                 // Check that the number of clubs joined is 0 since it is a new student
-                int sizeJoinedClubs = dbStudent.getJoinedClubs().size();
+                int sizeJoinedClubs = dbStudent.getJoinedClubsEmails().size();
                 assertEquals(0, sizeJoinedClubs);
             }
 
@@ -77,7 +77,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -111,7 +111,7 @@ public class StudentLoginInteractorTest {
     @Test
     public void failureTestEmptyField() {
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the input data
         StudentLoginInputData inputDataNoEmail = new StudentLoginInputData("", studentPassword);
@@ -149,7 +149,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -190,7 +190,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);

--- a/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
+++ b/src/test/java/use_case/login/student_login/StudentLoginInteractorTest.java
@@ -1,6 +1,6 @@
 package use_case.login.student_login;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.Student;
 import entity.user.StudentFactory;
 import entity.user.StudentUserFactory;
@@ -24,7 +24,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -77,7 +77,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -111,7 +111,7 @@ public class StudentLoginInteractorTest {
     @Test
     public void failureTestEmptyField() {
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the input data
         StudentLoginInputData inputDataNoEmail = new StudentLoginInputData("", studentPassword);
@@ -149,7 +149,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);
@@ -190,7 +190,7 @@ public class StudentLoginInteractorTest {
         StudentFactory studentFactory = new StudentUserFactory();
 
         // Initialise the DAO. In our case, we will the in memory DAO for tests.
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create the student (register)
         Student testStudent = studentFactory.create(studentUsername, studentEmail, studentPassword);

--- a/src/test/java/use_case/signup/club_signup/ClubSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/club_signup/ClubSignupInteractorTest.java
@@ -1,7 +1,6 @@
 package use_case.signup.club_signup;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.user.Club;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
 import org.junit.jupiter.api.Test;
@@ -16,7 +15,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -49,7 +48,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a Club with the same name
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         ClubFactory clubFactory = new ClubUserFactory();
         userRepository.saveClub(clubFactory.create("test club", "ok@k.com", "pass"));
 
@@ -81,7 +80,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a Club with the same email
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         ClubFactory clubFactory = new ClubUserFactory();
         userRepository.saveClub(clubFactory.create("test club", "ok@k.com", "pass"));
@@ -114,7 +113,7 @@ public class ClubSignupInteractorTest {
                 "password1", "password2");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -143,7 +142,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -173,7 +172,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -202,7 +201,7 @@ public class ClubSignupInteractorTest {
                 "passwo", "passwo");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -232,7 +231,7 @@ public class ClubSignupInteractorTest {
                 password, password);
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -261,7 +260,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -290,7 +289,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -316,7 +315,7 @@ public class ClubSignupInteractorTest {
     @Test
     void switchToLoginTest() {
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {

--- a/src/test/java/use_case/signup/club_signup/ClubSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/club_signup/ClubSignupInteractorTest.java
@@ -1,7 +1,8 @@
 package use_case.signup.club_signup;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Club;
+import entity.user.ClubFactory;
 import entity.user.ClubUserFactory;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -48,8 +49,9 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a Club with the same name
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        userRepository.saveClub(new Club("test club", "ok@k.com", "pass", null, null));
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        ClubFactory clubFactory = new ClubUserFactory();
+        userRepository.saveClub(clubFactory.create("test club", "ok@k.com", "pass"));
 
 
         // This creates a successPresenter that tests whether the test case is as we expect.
@@ -79,8 +81,10 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a Club with the same email
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        userRepository.saveClub(new Club("test club", "ok@k.com", "pass", null, null));
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+
+        ClubFactory clubFactory = new ClubUserFactory();
+        userRepository.saveClub(clubFactory.create("test club", "ok@k.com", "pass"));
 
 
         // This creates a successPresenter that tests whether the test case is as we expect.
@@ -110,7 +114,7 @@ public class ClubSignupInteractorTest {
                 "password1", "password2");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -139,7 +143,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -169,7 +173,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -198,7 +202,7 @@ public class ClubSignupInteractorTest {
                 "passwo", "passwo");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -228,7 +232,7 @@ public class ClubSignupInteractorTest {
                 password, password);
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -257,7 +261,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -286,7 +290,7 @@ public class ClubSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {
@@ -312,7 +316,7 @@ public class ClubSignupInteractorTest {
     @Test
     void switchToLoginTest() {
         // Uses an in memory database to test the use case
-        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        ClubSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         ClubSignupOutputBoundary successPresenter = new ClubSignupOutputBoundary() {

--- a/src/test/java/use_case/signup/student_signup/StudentSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/student_signup/StudentSignupInteractorTest.java
@@ -1,7 +1,8 @@
 package use_case.signup.student_signup;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.user.Student;
+import entity.user.StudentFactory;
 import entity.user.StudentUserFactory;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -49,8 +50,9 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a student with the same name
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        userRepository.saveStudent(new Student("test club", "ok@k.com", "pass", null));
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentFactory studentFactory = new StudentUserFactory();
+        userRepository.saveStudent(studentFactory.create("test club", "ok@k.com", "pass"));
 
 
         // This creates a successPresenter that tests whether the test case is as we expect.
@@ -80,8 +82,9 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a student with the same email
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        userRepository.saveStudent(new Student("test club", "ok@k.com", "pass", null));
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentFactory studentFactory = new StudentUserFactory();
+        userRepository.saveStudent(studentFactory.create("test club", "ok@k.com", "pass"));
 
 
         // This creates a successPresenter that tests whether the test case is as we expect.
@@ -111,7 +114,7 @@ public class StudentSignupInteractorTest {
                 "password1", "password2");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -140,7 +143,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -170,7 +173,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -199,7 +202,7 @@ public class StudentSignupInteractorTest {
                 "passwo", "passwo");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -229,7 +232,7 @@ public class StudentSignupInteractorTest {
                 password, password);
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -258,7 +261,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -287,7 +290,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -313,7 +316,7 @@ public class StudentSignupInteractorTest {
     @Test
     void switchToLoginTest() {
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {

--- a/src/test/java/use_case/signup/student_signup/StudentSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/student_signup/StudentSignupInteractorTest.java
@@ -1,7 +1,6 @@
 package use_case.signup.student_signup;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.user.Student;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.StudentFactory;
 import entity.user.StudentUserFactory;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -50,7 +49,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a student with the same name
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         StudentFactory studentFactory = new StudentUserFactory();
         userRepository.saveStudent(studentFactory.create("test club", "ok@k.com", "pass"));
 
@@ -82,7 +81,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case and stores a student with the same email
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         StudentFactory studentFactory = new StudentUserFactory();
         userRepository.saveStudent(studentFactory.create("test club", "ok@k.com", "pass"));
 
@@ -114,7 +113,7 @@ public class StudentSignupInteractorTest {
                 "password1", "password2");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -143,7 +142,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -173,7 +172,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -202,7 +201,7 @@ public class StudentSignupInteractorTest {
                 "passwo", "passwo");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -232,7 +231,7 @@ public class StudentSignupInteractorTest {
                 password, password);
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -261,7 +260,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -290,7 +289,7 @@ public class StudentSignupInteractorTest {
                 "password", "password");
 
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {
@@ -316,7 +315,7 @@ public class StudentSignupInteractorTest {
     @Test
     void switchToLoginTest() {
         // Uses an in memory database to test the use case
-        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataStudentAccessObject();
+        StudentSignupUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         // This creates a successPresenter that tests whether the test case is as we expect.
         StudentSignupOutputBoundary successPresenter = new StudentSignupOutputBoundary() {

--- a/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
@@ -1,8 +1,6 @@
 package use_case.student_homepage.dislike;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
@@ -20,7 +18,7 @@ public class StudentDislikeInteractorTest {
     void successDislikedTest() {
         // This test shows that a dislike is properly added after a user dislikes a post.
         // Set up in-memory repository
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();
@@ -80,7 +78,7 @@ public class StudentDislikeInteractorTest {
     void successUndislikedTest() {
         // This test shows whether the dislike is properly removed when a user removes their dislike from a post.
         // Set up in-memory repository
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();

--- a/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
@@ -1,13 +1,12 @@
 package use_case.student_homepage.dislike;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -21,17 +20,17 @@ public class StudentDislikeInteractorTest {
     void successDislikedTest() {
         // This test shows that a dislike is properly added after a user dislikes a post.
         // Set up in-memory repository
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students1, new DataStoreArrays<>());
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        joinedClubs.add(club);
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
+        student.joinClub(club);
         club.addClubMember(student);
 
 
@@ -50,8 +49,8 @@ public class StudentDislikeInteractorTest {
         postData.put("content", post.getContent());
         postData.put("likes", post.numberOfLikes());
         postData.put("dislikes", post.numberOfDislikes());
-        postData.put("liked", post.getLikes().contains(student));
-        postData.put("disliked", post.getDislikes().contains(student));
+        postData.put("liked", post.getLikes().contains(student.getEmail()));
+        postData.put("disliked", post.getDislikes().contains(student.getEmail()));
         postData.put("club-email", club.getEmail());
         postData.put("time", post.timeOfPosting());
         postData.put("date", post.dateOfPosting());
@@ -80,17 +79,17 @@ public class StudentDislikeInteractorTest {
     void successUndislikedTest() {
         // This test shows whether the dislike is properly removed when a user removes their dislike from a post.
         // Set up in-memory repository
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students1, new DataStoreArrays<>());
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        joinedClubs.add(club);
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
+        student.joinClub(club);
         club.addClubMember(student);
 
 
@@ -109,8 +108,8 @@ public class StudentDislikeInteractorTest {
         postData.put("content", post.getContent());
         postData.put("likes", post.numberOfLikes());
         postData.put("dislikes", post.numberOfDislikes());
-        postData.put("liked", post.getLikes().contains(student));
-        postData.put("disliked", post.getDislikes().contains(student));
+        postData.put("liked", post.getLikes().contains(student.getEmail()));
+        postData.put("disliked", post.getDislikes().contains(student.getEmail()));
         postData.put("club-email", club.getEmail());
         postData.put("time", post.timeOfPosting());
         postData.put("date", post.dateOfPosting());

--- a/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/dislike/StudentDislikeInteractorTest.java
@@ -42,6 +42,7 @@ public class StudentDislikeInteractorTest {
 
         club.addClubPost(post);
         dao.saveClub(club);
+        dao.savePost(post, club);
         dao.saveStudent(student);
         // Input Data
         Map<String, Object> postData = new HashMap<String, Object>();
@@ -99,8 +100,8 @@ public class StudentDislikeInteractorTest {
                 + "a photo contest around the theme black and white photos and would like to hear your feedback!" +
                 " Get creative," + "ditch the colors, and win prizes!");
         post.addDislike(student);
-        club.addClubPost(post);
         dao.saveClub(club);
+        dao.savePost(post, club);
         dao.saveStudent(student);
         // Input Data
         Map<String, Object> postData = new HashMap<String, Object>();

--- a/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
@@ -37,10 +37,11 @@ public class StudentLikeInteractorTest {
         Post post = postFactory.create("Black and White Photo contest announcement.", "We're planning to host"
                 + "a photo contest around the theme black and white photos and would like to hear your feedback!" +
                 " Get creative," + "ditch the colors, and win prizes!");
-
         club.addClubPost(post);
         dao.saveClub(club);
+        dao.savePost(post, club);
         dao.saveStudent(student);
+
         // Input Data
         Map<String, Object> postData = new HashMap<String, Object>();
         postData.put("title", post.getTitle());
@@ -94,8 +95,8 @@ public class StudentLikeInteractorTest {
                 + "a photo contest around the theme black and white photos and would like to hear your feedback!" +
                 " Get creative," + "ditch the colors, and win prizes!");
         post.addLike(student);
-        club.addClubPost(post);
         dao.saveClub(club);
+        dao.savePost(post, club);
         dao.saveStudent(student);
         // Input Data
         Map<String, Object> postData = new HashMap<String, Object>();

--- a/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
@@ -1,8 +1,6 @@
 package use_case.student_homepage.like;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
@@ -18,7 +16,7 @@ public class StudentLikeInteractorTest {
     @Test
     void successLikedTest() {
         // Set up in-memory repository
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();
@@ -76,7 +74,7 @@ public class StudentLikeInteractorTest {
     @Test
     void successUnlikedTest() {
         // Set up in-memory repository
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();

--- a/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/like/StudentLikeInteractorTest.java
@@ -1,14 +1,12 @@
 package use_case.student_homepage.like;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.post.Announcement;
 import entity.post.AnnouncementFactory;
 import entity.post.Post;
 import entity.post.PostFactory;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -20,17 +18,17 @@ public class StudentLikeInteractorTest {
     @Test
     void successLikedTest() {
         // Set up in-memory repository
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students1, new DataStoreArrays<>());
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        joinedClubs.add(club);
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
+        student.joinClub(club);
         club.addClubMember(student);
 
 
@@ -49,8 +47,8 @@ public class StudentLikeInteractorTest {
         postData.put("content", post.getContent());
         postData.put("likes", post.numberOfLikes());
         postData.put("dislikes", post.numberOfDislikes());
-        postData.put("liked", post.getLikes().contains(student));
-        postData.put("disliked", post.getDislikes().contains(student));
+        postData.put("liked", post.getLikes().contains(student.getEmail()));
+        postData.put("disliked", post.getDislikes().contains(student.getEmail()));
         postData.put("club-email", club.getEmail());
         postData.put("time", post.timeOfPosting());
         postData.put("date", post.dateOfPosting());
@@ -77,19 +75,18 @@ public class StudentLikeInteractorTest {
     @Test
     void successUnlikedTest() {
         // Set up in-memory repository
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students1, new DataStoreArrays<>());
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        joinedClubs.add(club);
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
+        student.joinClub(club);
         club.addClubMember(student);
-
 
         PostFactory postFactory = new AnnouncementFactory();
         // Create a post for the club
@@ -106,8 +103,8 @@ public class StudentLikeInteractorTest {
         postData.put("content", post.getContent());
         postData.put("likes", post.numberOfLikes());
         postData.put("dislikes", post.numberOfDislikes());
-        postData.put("liked", post.getLikes().contains(student));
-        postData.put("disliked", post.getDislikes().contains(student));
+        postData.put("liked", post.getLikes().contains(student.getEmail()));
+        postData.put("disliked", post.getDislikes().contains(student.getEmail()));
         postData.put("club-email", club.getEmail());
         postData.put("time", post.timeOfPosting());
         postData.put("date", post.dateOfPosting());

--- a/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
@@ -1,11 +1,10 @@
 package use_case.student_homepage.show_clubs;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 
 import entity.data_structure.DataStoreArrays;
 import entity.post.Post;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 
@@ -19,13 +18,15 @@ public class StudentShowClubsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
         // Create 3 example clubs and a student.
-        Club climbingClub = new Club("Climbing club", "utcc@utoronto.ca", "12345678", new DataStoreArrays<Student>(), new DataStoreArrays<Post>());
-        Club outdoorsclub = new Club("Outdoors club", "utoc@utoronto.ca", "secure", new DataStoreArrays<Student>(), new DataStoreArrays<Post>());
-        Club rlClub = new Club("Rocket League club", "rlatuoft@utoronto.ca", "more_secure", new DataStoreArrays<Student>(), new DataStoreArrays<Post>());
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club climbingClub = clubFactory.create("Climbing club", "utcc@utoronto.ca", "12345678");
+        Club outdoorsclub = clubFactory.create("Outdoors club", "utoc@utoronto.ca", "secure");
+        Club rlClub = clubFactory.create("Rocket League club", "rlatuoft@utoronto.ca", "more_secure");
 
-        Student student = new Student("Fred", "frederik.brecht@mail.utoronto.ca", "password", new DataStoreArrays<>());
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Fred", "frederik.brecht@mail.utoronto.ca", "password");
         // Add the sample student as a member to the clubs.
         climbingClub.addClubMember(student);
         outdoorsclub.addClubMember(student);
@@ -85,7 +86,7 @@ public class StudentShowClubsInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with a club.
-        StudentShowClubsAccessInterface dao = new InMemoryUserDataAccessObject();
+        StudentShowClubsAccessInterface dao = new InMemoryUserDataStudentAccessObject();
 
         StudentShowClubsInputData inputData = new StudentShowClubsInputData("frederik.brecht@mail.utoronto.ca");
 

--- a/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
@@ -27,19 +27,6 @@ public class StudentShowClubsInteractorTest {
 
         StudentFactory studentFactory = new StudentUserFactory();
         Student student = studentFactory.create("Fred", "frederik.brecht@mail.utoronto.ca", "password");
-        // Add the sample student as a member to the clubs.
-        climbingClub.addClubMember(student);
-        outdoorsclub.addClubMember(student);
-        rlClub.addClubMember(student);
-        student.joinClub(outdoorsclub);
-        student.joinClub(climbingClub);
-        student.joinClub(rlClub);
-
-        // Save the sample student and clubs to the in memory database.
-        dao.saveStudent(student);
-        dao.saveClub(climbingClub);
-        dao.saveClub(outdoorsclub);
-        dao.saveClub(rlClub);
 
         // set up a sample List of Maps to compare to the output test data
         ArrayList<HashMap<String, String>> sampleList  = new ArrayList<>();
@@ -63,6 +50,20 @@ public class StudentShowClubsInteractorTest {
         sampleList.add(climbingClubHash);
         sampleList.add(rlClubHash);
 
+        // Add the sample student as a member to the clubs.
+        climbingClub.addClubMember(student);
+        outdoorsclub.addClubMember(student);
+        rlClub.addClubMember(student);
+        student.joinClub(outdoorsclub);
+        student.joinClub(climbingClub);
+        student.joinClub(rlClub);
+
+        // Save the sample student and clubs to the in memory database.
+        dao.saveStudent(student);
+        dao.saveClub(outdoorsclub);
+        dao.saveClub(climbingClub);
+        dao.saveClub(rlClub);
+
         // prepare the inputData.
         StudentShowClubsInputData inputData = new StudentShowClubsInputData(student.getEmail());
 
@@ -71,7 +72,7 @@ public class StudentShowClubsInteractorTest {
             @Override
             public void prepareClubsContent(StudentShowClubsOutputData studentShowClubsOutputData) {
                 assertEquals("frederik.brecht@mail.utoronto.ca", studentShowClubsOutputData.getCurrStudentEmail());
-                assertEquals(sampleList, studentShowClubsOutputData.getClubs());
+                assertTrue(sampleList.equals(studentShowClubsOutputData.getClubs()));
             }
 
             @Override

--- a/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_clubs/StudentShowClubsInteractorTest.java
@@ -1,9 +1,7 @@
 package use_case.student_homepage.show_clubs;
 
-import data_access.InMemoryUserDataStudentAccessObject;
+import data_access.InMemoryUserDataAccessObject;
 
-import entity.data_structure.DataStoreArrays;
-import entity.post.Post;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +16,7 @@ public class StudentShowClubsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
         // Create 3 example clubs and a student.
         ClubFactory clubFactory = new ClubUserFactory();
         Club climbingClub = clubFactory.create("Climbing club", "utcc@utoronto.ca", "12345678");
@@ -87,7 +85,7 @@ public class StudentShowClubsInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with a club.
-        StudentShowClubsAccessInterface dao = new InMemoryUserDataStudentAccessObject();
+        StudentShowClubsAccessInterface dao = new InMemoryUserDataAccessObject();
 
         StudentShowClubsInputData inputData = new StudentShowClubsInputData("frederik.brecht@mail.utoronto.ca");
 

--- a/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
@@ -1,13 +1,12 @@
 package use_case.student_homepage.show_posts;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStoreArrays;
 import entity.post.Announcement;
 import entity.post.AnnouncementFactory;
 import entity.post.PostFactory;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
-import use_case.student_homepage.show_clubs.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,12 +20,13 @@ public class StudentShowPostsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
         // Create a sample club and a student.
         UserFactory clubFactory = new ClubUserFactory();
         Club climbingClub = (Club) clubFactory.create("Climbing club", "utcc@utoronto.ca", "secure");
 
-        Student student = new Student("Fred", "frederik.brecht@mail.utoronto.ca", "password", new DataStoreArrays<>());
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Fred", "frederik.brecht@mail.utoronto.ca", "password");
 
         // Create 3 sample posts.
         PostFactory announcementFactory = new AnnouncementFactory();
@@ -37,8 +37,8 @@ public class StudentShowPostsInteractorTest {
         announcement1Data.put("content", announcement1.getContent());
         announcement1Data.put("likes", announcement1.numberOfLikes());
         announcement1Data.put("dislikes", announcement1.numberOfDislikes());
-        announcement1Data.put("liked", announcement1.getLikes().contains(student));
-        announcement1Data.put("disliked", announcement1.getDislikes().contains(student));
+        announcement1Data.put("liked", announcement1.getLikes().contains(student.getEmail()));
+        announcement1Data.put("disliked", announcement1.getDislikes().contains(student.getEmail()));
         announcement1Data.put("club-email", climbingClub.getEmail());
         announcement1Data.put("time", announcement1.timeOfPosting());
         announcement1Data.put("date", announcement1.dateOfPosting());
@@ -48,8 +48,8 @@ public class StudentShowPostsInteractorTest {
         announcement2Data.put("content", announcement2.getContent());
         announcement2Data.put("likes", announcement2.numberOfLikes());
         announcement2Data.put("dislikes", announcement2.numberOfDislikes());
-        announcement2Data.put("liked", announcement2.getLikes().contains(student));
-        announcement2Data.put("disliked", announcement2.getDislikes().contains(student));
+        announcement2Data.put("liked", announcement2.getLikes().contains(student.getEmail()));
+        announcement2Data.put("disliked", announcement2.getDislikes().contains(student.getEmail()));
         announcement2Data.put("club-email", climbingClub.getEmail());
         announcement2Data.put("time", announcement2.timeOfPosting());
         announcement2Data.put("date", announcement2.dateOfPosting());
@@ -59,8 +59,8 @@ public class StudentShowPostsInteractorTest {
         announcement3Data.put("content", announcement3.getContent());
         announcement3Data.put("likes", announcement3.numberOfLikes());
         announcement3Data.put("dislikes", announcement3.numberOfDislikes());
-        announcement3Data.put("liked", announcement3.getLikes().contains(student));
-        announcement3Data.put("disliked", announcement3.getDislikes().contains(student));
+        announcement3Data.put("liked", announcement3.getLikes().contains(student.getEmail()));
+        announcement3Data.put("disliked", announcement3.getDislikes().contains(student.getEmail()));
         announcement3Data.put("club-email", climbingClub.getEmail());
         announcement3Data.put("time", announcement3.timeOfPosting());
         announcement3Data.put("date", announcement3.dateOfPosting());
@@ -95,14 +95,14 @@ public class StudentShowPostsInteractorTest {
                 fail("Unexpected fail call.");
             }
         };
-        StudentShowPostsInputBoundary interactor = new StudentShowPostsInteractor(dao, successPresenter);
+        StudentShowPostsInputBoundary interactor = new StudentShowPostsInteractor(dao, dao, successPresenter);
         interactor.execute(inputData);
     }
 
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with a club.
-        StudentShowPostsAccessInterface dao = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
 
         StudentShowPostsInputData inputData = new StudentShowPostsInputData("frederik.brecht@mail.utoronto.ca");
 
@@ -121,7 +121,7 @@ public class StudentShowPostsInteractorTest {
             }
         };
 
-        StudentShowPostsInputBoundary interactor = new StudentShowPostsInteractor(dao, successPresenter);
+        StudentShowPostsInputBoundary interactor = new StudentShowPostsInteractor(dao, dao, successPresenter);
         interactor.execute(inputData);
     }
 }

--- a/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
@@ -64,14 +64,14 @@ public class StudentShowPostsInteractorTest {
         announcement3Data.put("club-email", climbingClub.getEmail());
         announcement3Data.put("time", announcement3.timeOfPosting());
         announcement3Data.put("date", announcement3.dateOfPosting());
-        climbingClub.addClubPost(announcement1);
-        climbingClub.addClubPost(announcement2);
-        climbingClub.addClubPost(announcement3);
 
         student.joinClub(climbingClub);
         climbingClub.addClubMember(student);
         dao.saveStudent(student);
         dao.saveClub(climbingClub);
+        dao.savePost(announcement1, climbingClub);
+        dao.savePost(announcement2, climbingClub);
+        dao.savePost(announcement3, climbingClub);
 
         Map<String, List<Map<String, Object>>> samplePostData = new HashMap<>();
         List<Map<String, Object>> samplePostsList = new ArrayList<>();

--- a/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
+++ b/src/test/java/use_case/student_homepage/show_posts/StudentShowPostsInteractorTest.java
@@ -1,7 +1,6 @@
 package use_case.student_homepage.show_posts;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.post.Announcement;
 import entity.post.AnnouncementFactory;
 import entity.post.PostFactory;
@@ -20,7 +19,7 @@ public class StudentShowPostsInteractorTest {
     @Test
     void successTest() {
         // Uses an in memory database to test the use case with a club
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
         // Create a sample club and a student.
         UserFactory clubFactory = new ClubUserFactory();
         Club climbingClub = (Club) clubFactory.create("Climbing club", "utcc@utoronto.ca", "secure");
@@ -102,7 +101,7 @@ public class StudentShowPostsInteractorTest {
     @Test
     void failTest() {
         // Uses an in memory database to test the use case with a club.
-        InMemoryUserDataStudentAccessObject dao = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject dao = new InMemoryUserDataAccessObject();
 
         StudentShowPostsInputData inputData = new StudentShowPostsInputData("frederik.brecht@mail.utoronto.ca");
 

--- a/src/test/java/use_case/student_join_club/StudentJoinClubInteractorTest.java
+++ b/src/test/java/use_case/student_join_club/StudentJoinClubInteractorTest.java
@@ -1,11 +1,8 @@
 package use_case.student_join_club;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
-import view.ClubCreatePostView;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,7 +10,7 @@ public class StudentJoinClubInteractorTest {
     @Test
     void successTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();
@@ -54,7 +51,7 @@ public class StudentJoinClubInteractorTest {
     @Test
     void clubDoesNotExistTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a student
         StudentFactory studentFactory = new StudentUserFactory();
@@ -85,7 +82,7 @@ public class StudentJoinClubInteractorTest {
     @Test
     void studentAlreadyInClubTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();

--- a/src/test/java/use_case/student_join_club/StudentJoinClubInteractorTest.java
+++ b/src/test/java/use_case/student_join_club/StudentJoinClubInteractorTest.java
@@ -1,11 +1,11 @@
 package use_case.student_join_club;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
+import view.ClubCreatePostView;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,16 +13,17 @@ public class StudentJoinClubInteractorTest {
     @Test
     void successTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students1 = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students1, null);
+        ClubFactory clubFactory = new ClubUserFactory();
+
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student not in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         userRepository.saveStudent(student);
         userRepository.saveClub(club);
 
@@ -35,8 +36,8 @@ public class StudentJoinClubInteractorTest {
             public void prepareSuccessView(StudentJoinClubOutputData data) {
                 assertEquals("Alice", data.getUsername());
                 assertFalse(data.isUseCaseFailed());
-                assertTrue(club.getClubMembers().contains(student));
-                assertTrue(student.getJoinedClubs().contains(club));
+                assertTrue(club.getClubMembersEmails().contains(student.getEmail()));
+                assertTrue(student.getJoinedClubsEmails().contains(club.getEmail()));
             }
 
             @Override
@@ -53,11 +54,11 @@ public class StudentJoinClubInteractorTest {
     @Test
     void clubDoesNotExistTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a student
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         userRepository.saveStudent(student);
 
         // Input data with a non-existent club
@@ -84,16 +85,16 @@ public class StudentJoinClubInteractorTest {
     @Test
     void studentAlreadyInClubTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> students = new DataStoreArrays<Student>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", students, null);
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student already in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         student.joinClub(club);
         club.addClubMember(student);
         userRepository.saveStudent(student);

--- a/src/test/java/use_case/student_leave_club/StudentLeaveClubInteractorTest.java
+++ b/src/test/java/use_case/student_leave_club/StudentLeaveClubInteractorTest.java
@@ -1,8 +1,6 @@
 package use_case.student_leave_club;
 
-import data_access.InMemoryUserDataStudentAccessObject;
-import entity.data_structure.DataStore;
-import entity.data_structure.DataStoreArrays;
+import data_access.InMemoryUserDataAccessObject;
 import entity.user.*;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +10,7 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void successTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();
@@ -54,7 +52,7 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void clubDoesNotExistTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a student
         StudentFactory studentFactory = new StudentUserFactory();
@@ -85,7 +83,7 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void studentNotInClubTest() {
         // Set up in-memory repositories
-        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
+        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
 
         // Create a club
         ClubFactory clubFactory = new ClubUserFactory();

--- a/src/test/java/use_case/student_leave_club/StudentLeaveClubInteractorTest.java
+++ b/src/test/java/use_case/student_leave_club/StudentLeaveClubInteractorTest.java
@@ -1,10 +1,9 @@
 package use_case.student_leave_club;
 
-import data_access.InMemoryUserDataAccessObject;
+import data_access.InMemoryUserDataStudentAccessObject;
 import entity.data_structure.DataStore;
 import entity.data_structure.DataStoreArrays;
-import entity.user.Club;
-import entity.user.Student;
+import entity.user.*;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,16 +12,16 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void successTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> clubMembers = new DataStoreArrays<>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", clubMembers, null);
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
 
         // Create a student already in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         student.joinClub(club);
         club.addClubMember(student);
         userRepository.saveStudent(student);
@@ -37,8 +36,8 @@ public class StudentLeaveClubInteractorTest {
             public void prepareSuccessView(StudentLeaveClubOutputData data) {
                 assertEquals("Alice", data.getUsername());
                 assertFalse(data.isUseCaseFailed());
-                assertFalse(club.getClubMembers().contains(student));
-                assertFalse(student.getJoinedClubs().contains(club));
+                assertFalse(club.getClubMembersEmails().contains(student.getEmail()));
+                assertFalse(student.getJoinedClubsEmails().contains(club.getEmail()));
             }
 
             @Override
@@ -55,11 +54,11 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void clubDoesNotExistTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a student
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         userRepository.saveStudent(student);
 
         // Input data with a non-existent club
@@ -86,17 +85,17 @@ public class StudentLeaveClubInteractorTest {
     @Test
     void studentNotInClubTest() {
         // Set up in-memory repositories
-        InMemoryUserDataAccessObject userRepository = new InMemoryUserDataAccessObject();
+        InMemoryUserDataStudentAccessObject userRepository = new InMemoryUserDataStudentAccessObject();
 
         // Create a club
-        DataStore<Student> clubMembers = new DataStoreArrays<>();
-        Club club = new Club("Photography Club", "photo@university.com", "password", clubMembers, null);
+        ClubFactory clubFactory = new ClubUserFactory();
+        Club club = clubFactory.create("Photography Club", "photo@university.com", "password");
         club.setClubDescription("For photography enthusiasts.");
         userRepository.saveClub(club);
 
         // Create a student not in the club
-        DataStore<Club> joinedClubs = new DataStoreArrays<>();
-        Student student = new Student("Alice", "alice@university.com", "password", joinedClubs);
+        StudentFactory studentFactory = new StudentUserFactory();
+        Student student = studentFactory.create("Alice", "alice@university.com", "password");
         userRepository.saveStudent(student);
 
         // Input data


### PR DESCRIPTION
**The problem:**

The way the data was stored in the entity cause problems in the firebase DB. The reason was the following: a student has a list of joined clubs, each club in that list has a list of members, each member in that list has a list of clubs and so on
basically it was an "infinite recursion". This was not a problem for the InMemoryDAO since the JVM does not actively try to unfold and uncover all the data (since no methods call the data past a certain point).

The Solution:

I completely overhauled the way the data is stored in the entities. This had a major advantage: there is no more coupling between Student, Club and Post. This was achieved by using DataStore lists of strings (where except for the posts, all strings were unique). Since the entity is such a core aspect of the code, this meant that I had to basically refactor, most use cases and the In memory DAO (without counting the entities themselves). 

A lot of stuff was added and removed, so please take a look. All the tests do pass, except now due to having more methods, the coverage is not 100%. Let's fix that by today!

I would be happy to answer any questions.